### PR TITLE
Changed calls to str.format to be backwards compatible with python 2.6

### DIFF
--- a/src/freeseer/framework/config.py
+++ b/src/freeseer/framework/config.py
@@ -42,7 +42,7 @@ class Config:
         self.configdir = configdir
         self.configfile = os.path.abspath("%s/freeseer.conf" % self.configdir)
         self.presentations_file = os.path.abspath('%s/presentations.db' % self.configdir)
-        self.uploaderfile = os.path.abspath("{}/uploader.conf".format(self.configdir))
+        self.uploaderfile = os.path.abspath("{0}/uploader.conf".format(self.configdir))
         
         self.uploader = UploaderConfig(self.uploaderfile)
         

--- a/src/freeseer/framework/logger.py
+++ b/src/freeseer/framework/logger.py
@@ -28,7 +28,7 @@ import logging.config
 import os
 import sys
 import socket
-from logging.handlers import SYSLOG_TCP_PORT
+#from logging.handlers import SYSLOG_TCP_PORT
 
 class Logger():
     '''

--- a/src/freeseer/frontend/videouploader/videouploader.py
+++ b/src/freeseer/frontend/videouploader/videouploader.py
@@ -355,7 +355,7 @@ class UploaderBackendThread(QtCore.QThread):
     
     def run(self):
         current_file = self.files[self.current]
-        logging.info("Uploading {}".format(current_file))
+        logging.info("Uploading {0}".format(current_file))
         
 #        from freeseer.framework import uploader
         # TODO: set global variables (uuuggghh) in uploader and run.

--- a/src/freeseer/plugins/metadata/gstreamerdiscoverer/gstreamerdiscoverer.py
+++ b/src/freeseer/plugins/metadata/gstreamerdiscoverer/gstreamerdiscoverer.py
@@ -88,6 +88,6 @@ def humantime(value):
     mn = sec / 60
     sec = sec % 60
 #    return "%2dm %2ds %3d" % (mn, sec, ms)
-    return "{:0>2}m {:0>2}s".format(mn, sec)
+    return "{0:0>2}m {1:0>2}s".format(mn, sec)
 
 #    return QtCore.QTime().addMSecs(ms)


### PR DESCRIPTION
This is a small amendment that fixes a small problem I ran into when I tried to run freeseer on windows(which, due to crazy gstreamer on windows issues, needs python 2.6). 

I didn't know that the syntax for format changed between python 2.7 and 2.6.  Also, I use format rather than % so that the code will be future proof (since the old % operator will is deprecated in python 3.2). (I also use new style classes for the same reason)
