### PR TITLE
Fixed README

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -25,9 +25,9 @@ Freeseer supports free (royalty free) audio and video codecs.
 
 -------------------------------------------------------------------------
 
-Download the latest installers: https://github.com/fosslc/freeseer/downloads
+Download the latest installers: https://github.com/Freeseer/freeseer/downloads
 
-Download the latest source code: https://github.com/fosslc/freeseer
+Download the latest source code: https://github.com/Freeseer/freeseer
 
 -------------------------------------------------------------------------
 
@@ -76,7 +76,7 @@ If you would like to create packages, read PACKAGE.txt for instructions.
 --------------------------------------------------------------------------
 
 Read more about hardware capture options here: 
-    http://wiki.github.com/fosslc/freeseer/capture-hardware
+    http://wiki.github.com/Freeseer/freeseer/capture-hardware
 
 If you wish to capture vga input using epiphan's vga2usb device:
     first, copy the vga2usb.ko driver to /lib/modules/<kernel version>
@@ -87,6 +87,6 @@ If you wish to capture vga input using epiphan's vga2usb device:
     "sudo cp vga2usb.conf /etc/modprobe.d/; depmod -a"
 
 For support, questions, suggestions or any other inquiries, visit:
-    http://wiki.github.com/fosslc/freeseer/
+    http://wiki.github.com/Freeseer/freeseer/
   
 ==========================================================================


### PR DESCRIPTION
Fixed README file to point at http://wiki.github.com/Freeseer/freeseer/* instead of http://wiki.github.com/fosslc/freeseer/.
