### PR TITLE
Adding a new Python module dependency on README apt-get command

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Developers
 
     ### Ubuntu Linux:
 
-        $ sudo apt-get install build-essential qt4-qmake pyqt4-dev-tools libqt4-dev libqt4-sql libqt4-sql-sqlite python-qt4 python-qt4-dev python-qt4-sql python2.6-dev python-feedparser python-setuptools
+        $ sudo apt-get install build-essential qt4-qmake pyqt4-dev-tools libqt4-dev libqt4-sql libqt4-sql-sqlite python-qt4 python-qt4-dev python-qt4-sql python2.6-dev python-feedparser python-setuptools python-xlib
         $ sudo easy_install yapsy
 
     ### Fedora Linux:


### PR DESCRIPTION
Changing README apt-get command to install the xlib python module, fixing a desktop plugin issue
