### PR TITLE
Added missing positional argument specifiers for string.format

### DIFF
--- a/src/freeseer/framework/core.py
+++ b/src/freeseer/framework/core.py
@@ -91,7 +91,7 @@ class FreeseerCore:
             
             # Add "-NN" to the end of a duplicate record name to make it unique.
             while(self.duplicate_exists("%s.%s" % (tempname, extension))):
-                tempname = "{}-{}".format(recordname, self.make_id_from_string(count, "0123456789"))
+                tempname = "{0}-{1}".format(recordname, self.make_id_from_string(count, "0123456789"))
                 count+=1
 
         recordname = "%s.%s" % (tempname, extension)


### PR DESCRIPTION
Positional argument specifiers were missing, was causing an error
when starting recording.
