### PR TITLE
Fixed the basic functionality of the PKGBUILD

### DIFF
--- a/pkg/arch/PKGBUILD
+++ b/pkg/arch/PKGBUILD
@@ -1,0 +1,42 @@
+# Contributor: Thanh Ha <thanh.ha@alumni.carleton.ca>
+pkgname=freeseer-git
+pkgver=20121111
+pkgrel=1
+pkgdesc="This project contains code for a video capture utility capable of capturing presentations. It captures vga output and audio and mixes them together to produce a video thus enabling you to capture great presentations, demos, or training material easily."
+arch=('i686' 'x86_64')
+url="http://wiki.github.com/Freeseer/freeseer/"
+license=('GPLv3')
+groups=()
+depends=(python2 python2-pyqt python2-feedparser gstreamer0.10-python)
+makedepends=(git)
+optdepends=()
+provides=()
+conflicts=()
+replaces=()
+backup=()
+options=()
+install=
+source=()
+noextract=()
+md5sums=() #generate with 'makepkg -g'
+
+_gitroot="git://github.com/Freeseer/freeseer.git"
+
+build() {
+  git clone $_gitroot 
+  cd ${srcdir}/freeseer/
+  git checkout -b pkgbuild origin/experimental
+  cd src/
+
+  make || return 1
+  cd freeseer/
+
+  mkdir -p $pkgdir/usr/bin/
+  mkdir -p $pkgdir/usr/lib/python2.7/site-packages/freeseer/
+  sed "s/python/python2/g" ../freeseer-record > $pkgdir/usr/bin/freeseer-record
+  sed "s/python/python2/g" ../freeseer-talkeditor > $pkgdir/usr/bin/freeseer-talkeditor
+  sed "s/python/python2/g" ../freeseer-config > $pkgdir/usr/bin/freeseer-config
+  chmod +x $pkgdir/usr/bin/freeseer-*
+  cp *.py $pkgdir/usr/lib/python2.7/site-packages/freeseer/
+  cp -r backend framework frontend $pkgdir/usr/lib/python2.7/site-packages/freeseer/
+}


### PR DESCRIPTION
This pull request fixes the issue with the outdated PKGBUILD. It can now be used to generate a working Freeseer installation on Arch Linux. I plan to add the icon. 

This pull request is for progress only. Don't merge yet!

Note: I have no control over the package owned by @zxiiro in the AUR so this has to be updated manually. I think doing so after my latest commit here would be best.
