### PR TITLE
Freeseer Exception when talk database is empty

### DIFF
--- a/src/freeseer/framework/core.py
+++ b/src/freeseer/framework/core.py
@@ -82,7 +82,7 @@ class FreeseerCore:
         If a record name with a .None extension is returned, the record name
         will just be ignored by the output plugin (e.g. Video Preview plugin).
         """
-        
+        recordname = None
         if presentation:
             recordname = self.make_record_name(presentation)
                     
@@ -93,13 +93,15 @@ class FreeseerCore:
             while(self.duplicate_exists("%s.%s" % (tempname, extension))):
                 tempname = "{0}-{1}".format(recordname, self.make_id_from_string(count, "0123456789"))
                 count+=1
+            if(tempname == None):
+                recordname = "NONAME.%s" % (extension)
+            else:
+                recordname = "%s.%s" % (tempname, extension)
+            if extension is not None:
+                logging.debug('Set record name to %s', recordname)
 
-        recordname = "%s.%s" % (tempname, extension)
-                     
-        if extension is not None:
-            logging.debug('Set record name to %s', recordname)        
-        
-        return recordname
+            return recordname
+        return "NONAME.noname.%s" % (extension)
 
 
     def make_record_name(self, presentation):
@@ -341,13 +343,22 @@ class FreeseerCore:
         
         To be used for populating the current recording's file metadata.
         """
-        return { "title" : presentation.title,
-                 "artist" : presentation.speaker,
-                 "performer" : presentation.speaker,
-                 "album" : presentation.event,
-                 "location" : presentation.room,
-                 "date" : str(datetime.date.today()),
-                 "comment" : presentation.description }
+        if (presentation):
+            return {"title" : presentation.title,
+                    "artist" : presentation.speaker,
+                    "performer" : presentation.speaker,
+                    "album" : presentation.event,
+                    "location" : presentation.room,
+                    "date" : str(datetime.date.today()),
+                    "comment" : presentation.description }
+
+        return { "title" : "NODATA",
+                 "artist" : "NODATA",
+                 "performer" : "NODATA",
+                 "album" : "NODATA",
+                 "location" : "NODATA",
+                 "date" : "NODATA",
+                 "comment" : "NODATA" }
 
 
     def load_backend(self, presentation):

--- a/src/freeseer/frontend/record/record.py
+++ b/src/freeseer/frontend/record/record.py
@@ -69,6 +69,10 @@ class RecordApp(QtGui.QMainWindow):
         # Initialize geometry, to be used for restoring window positioning.
         self.geometry = None
 
+        # Initialize current_event , current_room
+        self.current_event = None
+        self.current_room = None
+
         self.core = FreeseerCore(self.mainWidget.previewWidget.winId(), self.audio_feedback)
         self.config = self.core.get_config()
 
@@ -424,13 +428,14 @@ class RecordApp(QtGui.QMainWindow):
             # Select next talk if there is one within 15 minutes.
             starttime = QtCore.QDateTime().currentDateTime()
             stoptime = starttime.addSecs(900)
-            talkid = self.core.db.get_talk_between_time(self.current_event, self.current_room, 
-                                                        starttime.toString(), stoptime.toString())
-            if talkid is not None:
-                for i in range(self.mainWidget.talkComboBox.count()):
-                    if talkid == self.mainWidget.talkComboBox.model().index(i, 1).data(QtCore.Qt.DisplayRole).toString():
-                        self.mainWidget.talkComboBox.setCurrentIndex(i)
-            
+            if self.current_event is not None or self.current_room is not None:
+                talkid = self.core.db.get_talk_between_time(self.current_event, self.current_room,
+                                                            starttime.toString(), stoptime.toString())
+                if talkid is not None:
+                    for i in range(self.mainWidget.talkComboBox.count()):
+                        if talkid == self.mainWidget.talkComboBox.model().index(i, 1).data(QtCore.Qt.DisplayRole).toString():
+                            self.mainWidget.talkComboBox.setCurrentIndex(i)
+
     def pause(self, state):
         if (state): # Pause Recording.
             self.core.pause()


### PR DESCRIPTION
...talk-editor.

fix : The runaway bug at the recording when it is not registered in the talk-editor.

BEFORE
Freeseer will not stop even if you press the stop button
![Screen Shot 2013-02-20 at 18 24 14](https://f.cloud.github.com/assets/2756096/175211/6956db2a-7b3f-11e2-999e-3711a91f39ca.png)

AFTER
Even if data can not be taken from Talk editor ,Freeseer can start recording.
![Screen Shot 2013-02-20 at 18 26 22](https://f.cloud.github.com/assets/2756096/175223/a51351de-7b3f-11e2-85a5-a49d263011ca.png)
