### PR TITLE
#380 Youtube Upload CLI filename not properly escaped

### DIFF
--- a/src/freeseer/framework/completer.py
+++ b/src/freeseer/framework/completer.py
@@ -1,0 +1,45 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+'''
+freeseer - vga/presentation capture software
+
+Copyright (C) 2013  Free and Open Source Software Learning Centre
+http://fosslc.org
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+For support, questions, suggestions or any other inquiries, visit:
+http://wiki.github.com/Freeseer/freeseer/
+
+This code is modified from:
+http://stackoverflow.com/questions/6656819/filepath-autocompletion-using-users-input
+'''
+
+import readline
+import glob
+import os
+
+
+def complete(text, state):
+    if os.path.isdir((glob.glob(text + '*') + [None])[state]):
+        return (glob.glob(text + '*/') + [None])[state]
+    else:
+        return (glob.glob(text + '*') + [None])[state]
+
+
+def completer():
+    readline.set_completer_delims(' \t\n;')
+    readline.parse_and_bind("tab: complete")
+    readline.set_completer(complete)

--- a/src/freeseer/tools/youtube_uploader/youtube_upload.py
+++ b/src/freeseer/tools/youtube_uploader/youtube_upload.py
@@ -31,43 +31,50 @@ import shlex
 import mutagen.oggvorbis
 
 from lib.youtube_upload import youtube_upload
+from freeseer.framework.completer import completer
+
 
 def upload():
-	#------- Trying to default to the video directory
-	config = ConfigParser.ConfigParser()
-	configdir = os.path.abspath(os.path.expanduser('~/.freeseer/'))	      
-	# Config location
-	configfile = os.path.abspath("%s/freeseer.conf" % configdir)
-	config.readfp(open(configfile))
-	vpath = config.get('Global', 'video_directory')
+    #------- Trying to default to the video directory
+    config = ConfigParser.ConfigParser()
+    configdir = os.path.abspath(os.path.expanduser('~/.freeseer/'))
+    # Config location
+    configfile = os.path.abspath("%s/freeseer.conf" % configdir)
+    config.readfp(open(configfile))
+    vpath = config.get('Global', 'video_directory') + "/"
+    os.chdir(vpath)
+    email = raw_input("Email (user@example.com): ")
+    password = getpass.getpass()
+    #vfile = browse_video_directory()
+    # Enable tab completion
+    completer()
+    vfile = raw_input("File or Directory: " + vpath)
+    # Check whether the file exists, and ask again if not
+    while os.path.exists(vpath + vfile) == False:
+        print "Cannot find file or directory " + vpath + vfile
+        vfile = raw_input("File or Directory: " + vpath)
 
-	email = raw_input("Email (user@example.com): ")
-	password = getpass.getpass()
-	#vfile = browse_video_directory()
-	vfile = raw_input("File or Directory: "+vpath+"/")
+    # If the vfile is a directory then walk through the directory and upload
+    # all it's videos
+    if os.path.isdir(vpath + vfile):
 
-	# Check whether the file exists, and ask again if not
-	while os.path.exists(vpath+"/"+vfile) == False:
-		print "Cannot find file or directory " + vpath+"/"+vfile
-		vfile = raw_input("File or Directory: "+vpath+"/")
-	
-	# If the vfile is a directory then walk through the directory and upload all it's videos
-	if os.path.isdir(vpath+"/"+vfile):
-		for root, dirs, files in os.walk(vpath+"/"+vfile):
-			i=0
-			while i < len(files):
-				#print str(root)+"/"+files[i-1]
-				uploadToYouTube(str(root), files[i-1], email, password)
-				i=i+1
-	# Otherwise just upload the one video
-	else:
-		uploadToYouTube(vpath, vfile, email, password)
+        for root, dirs, files in os.walk(vpath + vfile):
+            i = 0
+            while i < len(files):
+                print str(root) + files[i - 1]
+                uploadToYouTube(str(root), files[i - 1], email, password)
+                i = i + 1
 
-	#ogg_vfile = ""
-	#mpg_vfile = vfile	
-	# This was for checking if the file video was an ogg or an mpg, checking if there existed a converted version already, 
-	# and converting it. Leaving it for now since conversion may be done in the future.
-	"""
+    # Otherwise just upload the one video
+    else:
+        uploadToYouTube(vpath, vfile, email, password)
+
+    # ogg_vfile = ""
+    # mpg_vfile = vfile
+    # This was for checking if the file video was an ogg or an mpg, checking if there existed a converted version already,
+    # and converting it. Leaving it for now since conversion may be done in
+    # the future.
+    """
 	if vfile[len(vfile)-3:] == "ogg":
 
 		metadata = mutagen.oggvorbis.Open(vpath+"/"+vfile)
@@ -100,40 +107,41 @@ def upload():
 			print metadata.pprint()
 
 	"""
-	#if ogg_vfile != "":
+    # if ogg_vfile != "":
 
 # Uploads an ogg or mpg to YouTube, using the metadata from an ogg
+
+
 def uploadToYouTube(vpath, vfile, email, password):
 
-	# Get the title and description if video is an ogg file
-	if vfile.lower().endswith(('.ogg', '.mpg')):
-		if vfile.lower().endswith('.ogg'):
-			metadata = mutagen.oggvorbis.Open(vpath+"/"+vfile)
-			#print metadata.pprint()
-			try:
-				title = metadata["title"][0]
-			except KeyError:
-				title = vfile
+    # Get the title and description if video is an ogg file
+    if vfile.lower().endswith(('.ogg', '.mpg')):
 
-			try:
-				description = metadata["description"][0]
-			except KeyError:
-				description = ""		
-	
-		else:
-			title = vfile
-			description = ""
-	else:
-		print vpath+"/"+vfile +" is not an ogg or mpg"
-		return
+        if vfile.lower().endswith('.ogg'):
+            metadata = mutagen.oggvorbis.Open(vpath + vfile)
+            # print metadata.pprint()
+            try:
+                title = metadata["title"][0]
+            except KeyError:
+                title = vfile
 
-	# Default category to education for now
-	category = "Education"
+            try:
+                description = metadata["description"][0]
+            except KeyError:
+                description = ""
 
-	youtube_upload.main_upload(shlex.split("--email="+email+" --password="+password+" --title="+title+" --category="+category+" --description="+'"'+description+'" ' + vpath+"/"+vfile))
+        else:
+            title = vfile
+            description = ""
+    else:
+        print vpath + vfile + " is not an ogg or mpg"
+        return
 
-
-
+    # Default category to education for now
+    category = "Education"
+    # Call 3rd parth library
+    youtube_upload.main(
+        shlex.split("-m" + email + " -p" + password + " -t" + escape(title) + " -c" + category + " " + escape(vpath + vfile)))
 
 
 #----------------------------------
@@ -156,13 +164,12 @@ def browse_video_directory():
 
     return videodir
 
-    #self.generalWidget.recordDirLineEdit.setText(videodir)
-    #self.generalWidget.recordDirLineEdit.emit(QtCore.SIGNAL("editingFinished()"))
+    # self.generalWidget.recordDirLineEdit.setText(videodir)
+    # self.generalWidget.recordDirLineEdit.emit(QtCore.SIGNAL("editingFinished()"))
 """
 
+# escape video title
 
 
-
-
-
-
+def escape(s):
+    return "'" + s.replace("'", "'\\''") + "'"


### PR DESCRIPTION
The current Youtube Upload CLI would crash when video titles/filename were not escaped properly. This patch fixes that, also included in the patch:
- tab auto-completion when selecting file for upload
