### PR TITLE
Button Changes

### DIFF
--- a/src/freeseer/frontend/configtool/AVWidget.py
+++ b/src/freeseer/frontend/configtool/AVWidget.py
@@ -26,6 +26,7 @@ http://wiki.github.com/Freeseer/freeseer/
 @author: Thanh Ha
 '''
 
+from PyQt4 import QtCore
 from PyQt4 import QtGui
 
 
@@ -43,6 +44,8 @@ class AVWidget(QtGui.QWidget):
         self.mainLayout = QtGui.QVBoxLayout()
         self.setLayout(self.mainLayout)
 
+        config_icon = QtGui.QIcon.fromTheme("preferences-system")
+
         #
         # Audio Input
         #
@@ -59,8 +62,11 @@ class AVWidget(QtGui.QWidget):
         self.audioMixerLabel.setSizePolicy(QtGui.QSizePolicy.Maximum, QtGui.QSizePolicy.Maximum)
         self.audioMixerComboBox = QtGui.QComboBox()
         self.audioMixerLabel.setBuddy(self.audioMixerComboBox)
-        self.audioMixerSetupPushButton = QtGui.QPushButton("Setup")
+        self.audioMixerSetupPushButton = QtGui.QToolButton()
+        self.audioMixerSetupPushButton.setText("Setup")
+        self.audioMixerSetupPushButton.setIcon(config_icon)
         self.audioMixerSetupPushButton.setSizePolicy(QtGui.QSizePolicy.Maximum, QtGui.QSizePolicy.Maximum)
+        self.audioMixerSetupPushButton.setToolButtonStyle(QtCore.Qt.ToolButtonIconOnly)
         self.audioLayout.addWidget(self.audioMixerLabel, 0, 0)
         self.audioLayout.addWidget(self.audioMixerComboBox, 0, 1)
         self.audioLayout.addWidget(self.audioMixerSetupPushButton, 0, 2)
@@ -81,8 +87,11 @@ class AVWidget(QtGui.QWidget):
         self.videoMixerLabel.setSizePolicy(QtGui.QSizePolicy.Maximum, QtGui.QSizePolicy.Maximum)
         self.videoMixerComboBox = QtGui.QComboBox()
         self.videoMixerLabel.setBuddy(self.videoMixerComboBox)
-        self.videoMixerSetupPushButton = QtGui.QPushButton("Setup")
+        self.videoMixerSetupPushButton = QtGui.QToolButton()
+        self.videoMixerSetupPushButton.setText("Setup")
+        self.videoMixerSetupPushButton.setIcon(config_icon)
         self.videoMixerSetupPushButton.setSizePolicy(QtGui.QSizePolicy.Maximum, QtGui.QSizePolicy.Maximum)
+        self.videoMixerSetupPushButton.setToolButtonStyle(QtCore.Qt.ToolButtonIconOnly)
         self.videoLayout.addWidget(self.videoMixerLabel, 0, 0)
         self.videoLayout.addWidget(self.videoMixerComboBox, 0, 1)
         self.videoLayout.addWidget(self.videoMixerSetupPushButton, 0, 2)
@@ -103,8 +112,11 @@ class AVWidget(QtGui.QWidget):
         self.fileLabel.setSizePolicy(QtGui.QSizePolicy.Maximum, QtGui.QSizePolicy.Maximum)
         self.fileComboBox = QtGui.QComboBox()
         self.fileLabel.setBuddy(self.fileComboBox)
-        self.fileSetupPushButton = QtGui.QPushButton("Setup")
+        self.fileSetupPushButton = QtGui.QToolButton()
+        self.fileSetupPushButton.setText("Setup")
+        self.fileSetupPushButton.setIcon(config_icon)
         self.fileSetupPushButton.setSizePolicy(QtGui.QSizePolicy.Maximum, QtGui.QSizePolicy.Maximum)
+        self.fileSetupPushButton.setToolButtonStyle(QtCore.Qt.ToolButtonIconOnly)
         self.fileLayout.addWidget(self.fileLabel, 0, 0)
         self.fileLayout.addWidget(self.fileComboBox, 0, 1)
         self.fileLayout.addWidget(self.fileSetupPushButton, 0, 2)
@@ -125,8 +137,11 @@ class AVWidget(QtGui.QWidget):
         self.streamLabel.setSizePolicy(QtGui.QSizePolicy.Maximum, QtGui.QSizePolicy.Maximum)
         self.streamComboBox = QtGui.QComboBox()
         self.streamLabel.setBuddy(self.streamComboBox)
-        self.streamSetupPushButton = QtGui.QPushButton("Setup")
+        self.streamSetupPushButton = QtGui.QToolButton()
+        self.streamSetupPushButton.setText("Setup")
+        self.streamSetupPushButton.setIcon(config_icon)
         self.streamSetupPushButton.setSizePolicy(QtGui.QSizePolicy.Maximum, QtGui.QSizePolicy.Maximum)
+        self.streamSetupPushButton.setToolButtonStyle(QtCore.Qt.ToolButtonIconOnly)
         self.streamLayout.addWidget(self.streamLabel, 0, 0)
         self.streamLayout.addWidget(self.streamComboBox, 0, 1)
         self.streamLayout.addWidget(self.streamSetupPushButton, 0, 2)

--- a/src/freeseer/frontend/configtool/PluginLoaderWidget.py
+++ b/src/freeseer/frontend/configtool/PluginLoaderWidget.py
@@ -26,7 +26,8 @@ http://wiki.github.com/Freeseer/freeseer/
 @author: Thanh Ha
 '''
 
-from PyQt4 import QtCore, QtGui
+from PyQt4 import QtCore
+from PyQt4 import QtGui
 
 
 class PluginLoaderWidget(QtGui.QWidget):
@@ -110,8 +111,8 @@ class PluginLoaderWidget(QtGui.QWidget):
         if plugin.plugin_object.get_widget() is not None:
             pluginConfigToolButton = QtGui.QToolButton()
             pluginConfigToolButton.setText("Settings")
-            configIcon = QtGui.QIcon.fromTheme("preferences-other")
-            pluginConfigToolButton.setIcon(configIcon)
+            config_icon = QtGui.QIcon.fromTheme("preferences-system")
+            pluginConfigToolButton.setIcon(config_icon)
             pluginConfigToolButton.setSizePolicy(QtGui.QSizePolicy.Maximum, QtGui.QSizePolicy.Maximum)
             pluginConfigToolButton.setToolButtonStyle(QtCore.Qt.ToolButtonIconOnly)
 

--- a/src/freeseer/frontend/configtool/configtool.py
+++ b/src/freeseer/frontend/configtool/configtool.py
@@ -26,7 +26,8 @@ import logging
 import os
 import re
 
-from PyQt4 import QtGui, QtCore
+from PyQt4 import QtGui
+from PyQt4 import QtCore
 from PyQt4.QtGui import QInputDialog
 from PyQt4.QtGui import QLineEdit
 from PyQt4.QtGui import QMessageBox
@@ -206,11 +207,19 @@ class ConfigToolApp(FreeseerApp):
         #
         self.avWidget.audioGroupBox.setTitle(self.app.translate("ConfigToolApp", "Audio Input"))
         self.avWidget.audioMixerLabel.setText(self.app.translate("ConfigToolApp", "Audio Mixer"))
-        self.avWidget.audioMixerSetupPushButton.setText(self.app.translate("ConfigToolApp", "Setup"))
+        self.avWidget.audioMixerSetupPushButton.setToolTip(self.app.translate("ConfigToolApp", "Setup"))
 
         self.avWidget.videoGroupBox.setTitle(self.app.translate("ConfigToolApp", "Video Input"))
         self.avWidget.videoMixerLabel.setText(self.app.translate("ConfigToolApp", "Video Mixer"))
-        self.avWidget.videoMixerSetupPushButton.setText(self.app.translate("ConfigToolApp", "Setup"))
+        self.avWidget.videoMixerSetupPushButton.setToolTip(self.app.translate("ConfigToolApp", "Setup"))
+
+        self.avWidget.fileGroupBox.setTitle(self.app.translate("ConfigToolApp", "Record to File"))
+        self.avWidget.fileLabel.setText(self.app.translate("ConfigToolApp", "File Format"))
+        self.avWidget.fileSetupPushButton.setToolTip(self.app.translate("ConfigToolApp", "Setup"))
+
+        self.avWidget.streamGroupBox.setTitle(self.app.translate("ConfigToolApp", "Record to Stream"))
+        self.avWidget.streamLabel.setText(self.app.translate("ConfigToolApp", "Stream Format"))
+        self.avWidget.streamSetupPushButton.setToolTip(self.app.translate("ConfigToolApp", "Setup"))
         # --- End AV Widget
 
     ###


### PR DESCRIPTION
Changing the setup buttons on the config interface as part of <a href="https://github.com/Freeseer/freeseer/issues/411">Issue 411</a>. 
- [x] Remove text from setup buttons on Recording tab
- [x] Use gear icon on button instead of 'Setup' on Recording tab
- [x] Use gear icon on button instead of toolbox icon for plugins (click on a plugin and see the listbox on right hand side

<a href="https://docs.google.com/document/d/12VwsurnMOcXSFQlQKo-ZIzozvFD3-bPSEudDq5L9un8/edit?usp=sharing">Project proposal document</a>
