### PR TITLE
#444 Separate recording logic from the concept of a talk/presentation

### DIFF
--- a/src/freeseer/framework/multimedia.py
+++ b/src/freeseer/framework/multimedia.py
@@ -22,7 +22,6 @@
 # For support, questions, suggestions or any other inquiries, visit:
 # http://wiki.github.com/Freeseer/freeseer/
 
-import datetime
 import logging
 import os
 
@@ -32,7 +31,6 @@ import pygst
 pygst.require("0.10")
 import gst
 
-from freeseer.framework.presentation import Presentation
 from freeseer.framework.plugin import IOutput
 from freeseer.framework.util import get_record_name
 
@@ -152,24 +150,11 @@ class Multimedia:
             self.current_state = Multimedia.STOP
             log.debug("Gstreamer stopped.")
 
-    def prepare_metadata(self, presentation):
-        """Returns a dictionary of tags and tag values.
-
-        To be used for populating the current recording's file metadata.
-        """
-        return {"title":     presentation.title,
-                "artist":    presentation.speaker,
-                "performer": presentation.speaker,
-                "album":     presentation.event,
-                "location":  presentation.room,
-                "date":      str(datetime.date.today()),
-                "comment":   presentation.description}
-
     ##
     ## Plugin Loading
     ##
 
-    def load_backend(self, presentation=None, filename=None):
+    def load_backend(self, filename, metadata=None):
         log.debug("Loading Output plugins...")
 
         filename_for_frontend = None
@@ -198,25 +183,12 @@ class Multimedia:
 
             extension = plugin.plugin_object.get_extension()
 
-            # Create a filename to record to.
-            if presentation is None and filename is not None:
-                record_name = get_record_name(extension, filename=filename, path=self.config.videodir)
-                presentation = Presentation(filename)
-            elif presentation is not None:
-                record_name = get_record_name(extension, presentation=presentation, path=self.config.videodir)
-            else:
-                # Invalid combination you must pass in a presentation or a filename
-                logging.error("Failed to configure recording name. No presentation or filename provided.")
-                return False
+            record_name = get_record_name(extension, filename=filename, path=self.config.videodir)
 
             # This is to ensure that we don't log a message when extension is None
             if extension is not None:
                 log.info('Set record name to %s', record_name)
                 filename_for_frontend = record_name
-
-            # Prepare metadata.
-            metadata = self.prepare_metadata(presentation)
-            #self.populate_metadata(data)
 
             record_location = os.path.abspath(self.config.videodir + '/' + record_name)
             plugin.plugin_object.set_recording_location(record_location)

--- a/src/freeseer/frontend/record/record.py
+++ b/src/freeseer/frontend/record/record.py
@@ -35,7 +35,6 @@ try:
 except AttributeError:
     _fromUtf8 = lambda s: s
 
-from freeseer.framework.presentation import Presentation
 from freeseer.framework.failure import Failure
 from freeseer.framework.util import get_free_space
 from freeseer.frontend.qtcommon.FreeseerApp import FreeseerApp
@@ -410,15 +409,19 @@ class RecordApp(FreeseerApp):
     def load_backend(self):
         """Prepares the backend for recording"""
         if self.current_presentation():
+            self.mainWidget.recordPushButton.setEnabled(True)
+            self.mainWidget.standbyPushButton.setToolTip(self.standbyString)
             presentation = self.current_presentation()
+            self.recently_recorded_video = self.controller.load_backend_with_presentation(presentation)
 
-        # If current presentation is no existant (empty talk database)
-        # use a default recording name.
+        # If current presentation is non-existent (empty talk database)
+        # disable Record button and set tooltip
         else:
-            presentation = Presentation(title=unicode("default"))
+            self.mainWidget.recordPushButton.setEnabled(False)
+            self.mainWidget.standbyPushButton.setToolTip('No presentations available')
+            return False
 
-        initialized, self.recently_recorded_video = self.controller.load_backend(presentation)
-        if initialized:
+        if self.recently_recorded_video:
             return True
         else:
             return False  # Error something failed while loading the backend


### PR DESCRIPTION
The changes included in this PR will decouple the backend recording logic (Multimedia class) from the Presentation class for improved modularity. This will especially help with #538 since, currently, an empty talk must be created even when recording straight to file.
- Add metadata parameter to load_backend function in Multimedia
- Disable Record button and set tool tip when no presentations are available
- Prepare record_name and metadata in RecordingController and add
  extension to file name in Multimedia
- Split RecordingController load_backend function into two functions: one
  accepting a filename, one accepting a presentation
- Change RecordingController load_backend function to only return a filename
  or None, and log an error if the load fails
- Change RecordApp to call load_backend_with_presentation
- Change convenience commands to call load_backend functions from
  RecordingController

This PR does NOT include unit tests.

Fixes issue #444 

Related proposal:
https://docs.google.com/document/d/1VdPLpdIgteMfr1l7TPIZQ1M5XUKcy7ffVWu41t5zvjk/edit#
