### PR TITLE
#494 Allow Add New Talk button to create an empty editable talk

### DIFF
--- a/src/freeseer/framework/database.py
+++ b/src/freeseer/framework/database.py
@@ -225,6 +225,14 @@ class QtDBConnector(object):
                 return True
         return False
 
+    def get_untitled_talks(self):
+        """Returns a list of the ids of all untitled talks"""
+        temp = []
+        result = QtSql.QSqlQuery('SELECT Id FROM presentations WHERE Title is NULL OR Title=""')
+        while result.next():
+            temp.append(result.value(0))
+        return temp
+
     #
     # Presentation Create, Update, Delete
     #
@@ -251,10 +259,12 @@ class QtDBConnector(object):
     def update_presentation(self, talk_id, presentation):
         """Updates an existing Presentation in the database."""
         QtSql.QSqlQuery(
-            '''UPDATE presentations SET Title="%s", Speaker="%s", Event="%s", Room="%s", Date="%s", Time="%s"
+            '''UPDATE presentations SET Title="%s", Speaker="%s", Description="%s", Category="%s", Event="%s", Room="%s", Date="%s", Time="%s"
                 WHERE Id="%s"''' %
             (presentation.title,
              presentation.speaker,
+             presentation.description,
+             presentation.category,
              presentation.event,
              presentation.room,
              presentation.date,

--- a/src/freeseer/frontend/talkeditor/CommandButtons.py
+++ b/src/freeseer/frontend/talkeditor/CommandButtons.py
@@ -42,9 +42,9 @@ class CommandButtons(QWidget):
         self.layout = QHBoxLayout()
         self.setLayout(self.layout)
 
-        #addIcon = QIcon.fromTheme("list-add")
         importIcon = QIcon.fromTheme("document-open")
         exportIcon = QIcon.fromTheme("document-save")
+        addIcon = QIcon.fromTheme("list-add")
         removeIcon = QIcon.fromTheme("list-remove")
         removeAllIcon = QIcon.fromTheme("window-close")
 
@@ -52,6 +52,8 @@ class CommandButtons(QWidget):
         self.importButton.setIcon(importIcon)
         self.exportButton = QPushButton('Export')
         self.exportButton.setIcon(exportIcon)
+        self.addButton = QPushButton('Add New Talk')
+        self.addButton.setIcon(addIcon)
         self.removeButton = QPushButton('Remove')
         self.removeButton.setIcon(removeIcon)
         self.removeAllButton = QPushButton('Remove All')
@@ -63,6 +65,7 @@ class CommandButtons(QWidget):
         self.searchButton.setIcon(self.searchIcon)
         self.layout.addWidget(self.importButton)
         self.layout.addWidget(self.exportButton)
+        self.layout.addWidget(self.addButton)
         self.layout.addWidget(self.removeButton)
         self.layout.addWidget(self.removeAllButton)
         self.layout.addStretch()

--- a/src/freeseer/frontend/talkeditor/TalkDetailsWidget.py
+++ b/src/freeseer/frontend/talkeditor/TalkDetailsWidget.py
@@ -37,8 +37,6 @@ from PyQt4.QtGui import QLineEdit
 from PyQt4.QtGui import QPlainTextEdit
 from PyQt4.QtGui import QTimeEdit
 from PyQt4.QtGui import QWidget
-from PyQt4.QtGui import QIcon
-from PyQt4.QtGui import QPushButton
 
 
 class TalkDetailsWidget(QWidget):
@@ -50,15 +48,6 @@ class TalkDetailsWidget(QWidget):
         self.setLayout(self.layout)
 
         self.buttonLayout = QHBoxLayout()
-
-        addIcon = QIcon.fromTheme("list-add")
-        self.addButton = QPushButton('Add New Talk')
-        self.addButton.setIcon(addIcon)
-        self.buttonLayout.addWidget(self.addButton)
-        saveIcon = QIcon.fromTheme("document-save")
-        self.saveButton = QPushButton('Save New Talk')
-        self.saveButton.setIcon(saveIcon)
-        self.buttonLayout.addWidget(self.saveButton)
 
         self.layout.addLayout(self.buttonLayout, 0, 1, 1, 1)
 
@@ -112,34 +101,34 @@ class TalkDetailsWidget(QWidget):
         self.layout.addWidget(self.descriptionTextEdit, 5, 1, 1, 3)
 
     def enable_input_fields(self):
-            self.titleLineEdit.setPlaceholderText("Enter Talk Title")
-            self.presenterLineEdit.setPlaceholderText("Enter Presenter Name")
-            self.categoryLineEdit.setPlaceholderText("Enter Category Type")
-            self.eventLineEdit.setPlaceholderText("Enter Event Name")
-            self.roomLineEdit.setPlaceholderText("Enter Room Location")
-            self.titleLineEdit.setEnabled(True)
-            self.presenterLineEdit.setEnabled(True)
-            self.categoryLineEdit.setEnabled(True)
-            self.eventLineEdit.setEnabled(True)
-            self.roomLineEdit.setEnabled(True)
-            self.dateEdit.setEnabled(True)
-            self.timeEdit.setEnabled(True)
-            self.descriptionTextEdit.setEnabled(True)
+        self.titleLineEdit.setPlaceholderText("Enter Talk Title")
+        self.presenterLineEdit.setPlaceholderText("Enter Presenter Name")
+        self.categoryLineEdit.setPlaceholderText("Enter Category Type")
+        self.eventLineEdit.setPlaceholderText("Enter Event Name")
+        self.roomLineEdit.setPlaceholderText("Enter Room Location")
+        self.titleLineEdit.setEnabled(True)
+        self.presenterLineEdit.setEnabled(True)
+        self.categoryLineEdit.setEnabled(True)
+        self.eventLineEdit.setEnabled(True)
+        self.roomLineEdit.setEnabled(True)
+        self.dateEdit.setEnabled(True)
+        self.timeEdit.setEnabled(True)
+        self.descriptionTextEdit.setEnabled(True)
 
     def disable_input_fields(self):
-            self.titleLineEdit.setPlaceholderText("")
-            self.presenterLineEdit.setPlaceholderText("")
-            self.categoryLineEdit.setPlaceholderText("")
-            self.eventLineEdit.setPlaceholderText("")
-            self.roomLineEdit.setPlaceholderText("")
-            self.titleLineEdit.setEnabled(False)
-            self.presenterLineEdit.setEnabled(False)
-            self.categoryLineEdit.setEnabled(False)
-            self.eventLineEdit.setEnabled(False)
-            self.roomLineEdit.setEnabled(False)
-            self.dateEdit.setEnabled(False)
-            self.timeEdit.setEnabled(False)
-            self.descriptionTextEdit.setEnabled(False)
+        self.titleLineEdit.setPlaceholderText("")
+        self.presenterLineEdit.setPlaceholderText("")
+        self.categoryLineEdit.setPlaceholderText("")
+        self.eventLineEdit.setPlaceholderText("")
+        self.roomLineEdit.setPlaceholderText("")
+        self.titleLineEdit.setEnabled(False)
+        self.presenterLineEdit.setEnabled(False)
+        self.categoryLineEdit.setEnabled(False)
+        self.eventLineEdit.setEnabled(False)
+        self.roomLineEdit.setEnabled(False)
+        self.dateEdit.setEnabled(False)
+        self.timeEdit.setEnabled(False)
+        self.descriptionTextEdit.setEnabled(False)
 
 if __name__ == "__main__":
     import sys

--- a/src/freeseer/tests/frontend/talkeditor/test_talkeditor.py
+++ b/src/freeseer/tests/frontend/talkeditor/test_talkeditor.py
@@ -111,6 +111,11 @@ class TestTalkEditorApp(unittest.TestCase):
     #     # now delete the talk we just created
     #     QtTest.QTest.mouseClick(self.talk_editor.editorWidget.removeButton, Qt.Qt.LeftButton)
 
+    def confirm_close(self):
+        active_widget = QtGui.QApplication.activeModalWidget()
+        if active_widget.inherits('QMessageBox'):
+            QtTest.QTest.keyClick(active_widget, Qt.Qt.Key_Y)  # Select 'Yes' to continue closing
+
     def test_file_menu_quit(self):
         '''
         Tests TalkEditorApp's File->Quit
@@ -119,6 +124,7 @@ class TestTalkEditorApp(unittest.TestCase):
         self.assertTrue(self.talk_editor.isVisible())
 
         # File->Quit
+        Qt.QTimer.singleShot(10, self.confirm_close)  # Set timer to continue close if message box appears
         self.talk_editor.actionExit.trigger()
         self.assertFalse(self.talk_editor.isVisible())
 


### PR DESCRIPTION
Allow Add New Talk button to create an empty editable talk.
This feature will eliminate the need for the Save Talk button.

Fix issue #494
Related to issue #427

Related proposal:
https://docs.google.com/document/d/1VdPLpdIgteMfr1l7TPIZQ1M5XUKcy7ffVWu41t5zvjk/edit#
