### PR TITLE
#500 Database update function should update description and category

### DIFF
--- a/src/freeseer/framework/database.py
+++ b/src/freeseer/framework/database.py
@@ -251,10 +251,13 @@ class QtDBConnector(object):
     def update_presentation(self, talk_id, presentation):
         """Updates an existing Presentation in the database."""
         QtSql.QSqlQuery(
-            '''UPDATE presentations SET Title="%s", Speaker="%s", Event="%s", Room="%s", Date="%s", Time="%s"
+            '''UPDATE presentations SET Title="%s", Speaker="%s", Description="%s", Category="%s",
+                Event="%s", Room="%s", Date="%s", Time="%s"
                 WHERE Id="%s"''' %
             (presentation.title,
              presentation.speaker,
+             presentation.description,
+             presentation.category,
              presentation.event,
              presentation.room,
              presentation.date,


### PR DESCRIPTION
- Include description and category in update_presentation function

This change is necessary for the new approach to editing talks, which will involve editing a blank talk in the table. Calling this method instead of submit() will prevent the focus on the current talk from being lost.

Fix issue #500
Related to issues #427, #494

Related proposal:
https://docs.google.com/document/d/1VdPLpdIgteMfr1l7TPIZQ1M5XUKcy7ffVWu41t5zvjk/edit#
