### PR TITLE
#508 Change Add New Talk button to a command button

### DIFF
--- a/src/freeseer/frontend/talkeditor/CommandButtons.py
+++ b/src/freeseer/frontend/talkeditor/CommandButtons.py
@@ -42,9 +42,9 @@ class CommandButtons(QWidget):
         self.layout = QHBoxLayout()
         self.setLayout(self.layout)
 
-        #addIcon = QIcon.fromTheme("list-add")
         importIcon = QIcon.fromTheme("document-open")
         exportIcon = QIcon.fromTheme("document-save")
+        addIcon = QIcon.fromTheme("list-add")
         removeIcon = QIcon.fromTheme("list-remove")
         removeAllIcon = QIcon.fromTheme("window-close")
 
@@ -52,6 +52,8 @@ class CommandButtons(QWidget):
         self.importButton.setIcon(importIcon)
         self.exportButton = QPushButton('Export')
         self.exportButton.setIcon(exportIcon)
+        self.addButton = QPushButton('Add New Talk')
+        self.addButton.setIcon(addIcon)
         self.removeButton = QPushButton('Remove')
         self.removeButton.setIcon(removeIcon)
         self.removeAllButton = QPushButton('Remove All')
@@ -63,6 +65,7 @@ class CommandButtons(QWidget):
         self.searchButton.setIcon(self.searchIcon)
         self.layout.addWidget(self.importButton)
         self.layout.addWidget(self.exportButton)
+        self.layout.addWidget(self.addButton)
         self.layout.addWidget(self.removeButton)
         self.layout.addWidget(self.removeAllButton)
         self.layout.addStretch()

--- a/src/freeseer/frontend/talkeditor/TalkDetailsWidget.py
+++ b/src/freeseer/frontend/talkeditor/TalkDetailsWidget.py
@@ -51,10 +51,6 @@ class TalkDetailsWidget(QWidget):
 
         self.buttonLayout = QHBoxLayout()
 
-        addIcon = QIcon.fromTheme("list-add")
-        self.addButton = QPushButton('Add New Talk')
-        self.addButton.setIcon(addIcon)
-        self.buttonLayout.addWidget(self.addButton)
         saveIcon = QIcon.fromTheme("document-save")
         self.saveButton = QPushButton('Save New Talk')
         self.saveButton.setIcon(saveIcon)

--- a/src/freeseer/frontend/talkeditor/talkeditor.py
+++ b/src/freeseer/frontend/talkeditor/talkeditor.py
@@ -136,6 +136,7 @@ class TalkEditorApp(FreeseerApp):
         self.connect(self.actionRemoveAll, QtCore.SIGNAL('triggered()'), self.confirm_reset)
 
         # Command Buttons
+        self.connect(self.commandButtons.addButton, SIGNAL('clicked()'), self.confirm_add)
         self.connect(self.commandButtons.removeButton, SIGNAL('clicked()'), self.remove_talk)
         self.connect(self.commandButtons.removeAllButton, SIGNAL('clicked()'), self.confirm_reset)
         self.connect(self.commandButtons.importButton, SIGNAL('clicked()'), self.show_import_talks_widget)
@@ -145,7 +146,6 @@ class TalkEditorApp(FreeseerApp):
         self.connect(self.commandButtons.searchLineEdit, SIGNAL('returnPressed()'), self.search_talks)
 
         # Talk Details Buttons
-        self.connect(self.talkDetailsWidget.addButton, SIGNAL('clicked()'), self.confirm_add)
         self.connect(self.talkDetailsWidget.saveButton, SIGNAL('clicked()'), self.add_talk)
 
         # Load default language
@@ -217,6 +217,7 @@ class TalkEditorApp(FreeseerApp):
         #self.commandButtons.addButton.setText(self.app.translate("TalkEditorApp", "Add"))
         self.commandButtons.importButton.setText(self.app.translate("TalkEditorApp", "Import"))
         self.commandButtons.exportButton.setText(self.app.translate("TalkEditorApp", "Export"))
+        self.commandButtons.addButton.setText(self.app.translate("TalkEditorApp", "Add New Talk"))
         self.commandButtons.removeButton.setText(self.app.translate("TalkEditorApp", "Remove"))
         self.commandButtons.removeAllButton.setText(self.app.translate("TalkEditorApp", "Remove All"))
         # --- End Command Butotn Translations


### PR DESCRIPTION
- Move 'Add New Talk' button from TalkDetailsWidget to CommandButtons
- Connect new 'Add New Talk' button to confirm_add

This change is based on the upcoming functionality for the Add New Talk button, which will involve adding an empty talk (no metadata) to the database.

Fixes issue #508
Related to issues #427, #494, #500

Related proposal:
https://docs.google.com/document/d/1VdPLpdIgteMfr1l7TPIZQ1M5XUKcy7ffVWu41t5zvjk/edit#
