### PR TITLE
added mock to dev_requirements.txt

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,2 +1,3 @@
 -r requirements.txt
 flake8
+mock


### PR DESCRIPTION
Added the missing dependency on "mock" to the dev requirements for pip. The dependency was added in 5a9261b35de08208a8edc876ec52657e1f14e9ca.
