### PR TITLE
#516 test_multimedia.py creating "test.ogg.ogg" in the users video directory

### DIFF
--- a/src/freeseer/tests/framework/test_multimedia.py
+++ b/src/freeseer/tests/framework/test_multimedia.py
@@ -36,12 +36,15 @@ class TestMultimedia(unittest.TestCase):
 
     def setUp(self):
         self.profile_manager = ProfileManager(tempfile.mkdtemp())
+        self.temp_video_dir = tempfile.mkdtemp()
         profile = self.profile_manager.get('testing')
         config = profile.get_config('freeseer.conf', settings.FreeseerConfig, ['Global'], read_only=True)
+        config.videodir = self.temp_video_dir
         plugin_manager = PluginManager(profile)
         self.multimedia = Multimedia(config, plugin_manager)
 
     def tearDown(self):
+        shutil.rmtree(self.temp_video_dir)
         shutil.rmtree(self.profile_manager._base_folder)
 
     def test_load_backend(self):


### PR DESCRIPTION
This fixes the issue where a file "test.ogg.ogg" was being created in the users video directory when running the test_multimedia.py.  This code now sets the videodir as a temporary directory before executing the test.   Setting the videodir before executing the test was implemented in aac07f1.

Link to issue: https://github.com/Freeseer/freeseer/issues/516
