### PR TITLE
#521 Modifying a talk using the details view hides the save button

### DIFF
--- a/src/freeseer/frontend/talkeditor/TalkDetailsWidget.py
+++ b/src/freeseer/frontend/talkeditor/TalkDetailsWidget.py
@@ -52,7 +52,7 @@ class TalkDetailsWidget(QWidget):
         self.buttonLayout = QHBoxLayout()
 
         saveIcon = QIcon.fromTheme("document-save")
-        self.saveButton = QPushButton('Save New Talk')
+        self.saveButton = QPushButton('Save Talk')
         self.saveButton.setIcon(saveIcon)
         self.buttonLayout.addWidget(self.saveButton)
 


### PR DESCRIPTION
- Enable Save Button only when an input field is modified by calling function
  enable_save
- Disable Save Button on init, and when input fields are autofilled or
  cleared by calling function disable_save
- Allow Save Button to be used for updating existing talks and adding new ones
- Change Save Button text to 'Save Talk'
- Edit docstring for function unsaved_details_exist

Fixes #521
