### PR TITLE
Pin flake8, pep8, and pytest at known working versions

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,5 +1,6 @@
 -r requirements.txt
-flake8
+pep8==1.4.6
+flake8==2.1.0
 mock
-pytest
-pytest-cov
+pytest==2.5.2
+pytest-cov==1.6

--- a/src/setup.py
+++ b/src/setup.py
@@ -61,5 +61,4 @@ setup(name=freeseer.NAME,
               'freeseer = freeseer:main',
           ],
       },
-      tests_require=['pytest-cov', 'pytest'],
       cmdclass={'test': PyTest})


### PR DESCRIPTION
There was a possible regression in pep8 > 1.4.6 so I've decided to pin it and our other testing tools in dev_requirements.txt.
