### PR TITLE
Added two more fedora dependencies to quick-start guide.

### DIFF
--- a/docs/source/quick-start.rst
+++ b/docs/source/quick-start.rst
@@ -81,7 +81,7 @@ Fedora Linux
 
 ::
 
-    $ sudo yum install git PyQt4-devel
+    $ sudo yum install git PyQt4-devel gstreamer-python sphinx python-sphinx
 
 .. warning:: This list may be incomplete. Please :doc:`let us know </contact>` if you notice any missing packages.
 


### PR DESCRIPTION
Added two dependencies for fedora in the quick-start guide.
- gstreamer-python is necessary for running freeseer.
- sphinx and python-sphinx necessary for running the test suite locally.

Verified that both of these are needed on a fresh fedora20 installation.
