### PR TITLE
Replace double-space with single-space after period

### DIFF
--- a/bump_versions.sh
+++ b/bump_versions.sh
@@ -12,11 +12,11 @@
 #
 #  This program is distributed in the hope that it will be useful,
 #  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 #  GNU General Public License for more details.
 #
 #  You should have received a copy of the GNU General Public License
-#  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#  along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 # For support, questions, suggestions or any other inquiries, visit:
 # http://wiki.github.com/Freeseer/freeseer/


### PR DESCRIPTION
The double-spaces after the periods have been replaced with more modern, stylistically accepted single-spaces.

(To be honest, I was just looking for something extremely simple to change so that I could practice getting over my fear of using Git to contribute to the project -- if there's a good reason to keep the double-space after each sentence, that's fine with me.)
