### PR TITLE
#562 Refactoring YouTube tests.

### DIFF
--- a/src/freeseer/tests/framework/test_youtube.py
+++ b/src/freeseer/tests/framework/test_youtube.py
@@ -25,40 +25,31 @@
 import os
 import unittest
 from mock import Mock
+import pytest
 
 from freeseer.framework.youtube import Response
 from freeseer.framework.youtube import YoutubeService
 
 
 class TestYoutubeService(unittest.TestCase):
-
     SAMPLE_VIDEO = os.path.join(os.path.dirname(__file__), 'sample_video.ogg')
-
-    def test_valid_video_file_ogg(self):
-        """Test valid_video_file function
-
-        Case: file ending in .ogg
-        """
-        self.assertTrue(YoutubeService.valid_video_file("/path/to/test.ogg"))
-
-    def test_valid_video_file_webm(self):
-        """Test valid_video_file function
-
-        Case: file ending in .webm
-        """
-        self.assertTrue(YoutubeService.valid_video_file("test.webm"))
-
-    def test_valid_video_file_invalid(self):
-        """Test valid_video_file function
-
-        Case: string not complying to valid file types
-        """
-        self.assertTrue(not YoutubeService.valid_video_file("asdfg.qwergb"))
+    SAMPLE_VIDEO_METADATA = {
+        'tags': [
+            'Freeseer',
+            'FOSSLC',
+            'Open Source',
+        ],
+        'categoryId': 27,
+        'description': 'At Test by Alex recorded on 2014-03-09',
+        'title': u'Test',
+    }
 
     def test_get_metadata(self):
-        """Test retrieval of metadata from video file"""
-        # a dictionary should always be returned
-        self.assertTrue(YoutubeService.get_metadata(self.SAMPLE_VIDEO))
+        """Test retrieval of metadata from video file.
+
+        Case: Returned metadata should be equal to sample video's metadata."""
+        metadata = YoutubeService.get_metadata(self.SAMPLE_VIDEO)
+        self.assertDictEqual(self.SAMPLE_VIDEO_METADATA, metadata)
 
     def test_upload_video(self):
         """Test uploading a video file using mocks"""
@@ -67,3 +58,13 @@ class TestYoutubeService(unittest.TestCase):
         response_code, response = youtube.upload_video(self.SAMPLE_VIDEO)
         youtube.upload_video.assert_called_with(self.SAMPLE_VIDEO)
         self.assertEqual(Response.SUCCESS, response_code)
+
+
+@pytest.mark.parametrize("video, expected", [
+    ("/path/to/test.ogg", True),
+    ("test.webm", True),
+    ("asdfg.qwergb", False),
+])
+def test_valid_video_file(video, expected):
+    """Tests valid_video_file function for all test cases."""
+    assert YoutubeService.valid_video_file(video) == expected

--- a/src/freeseer/tests/frontend/upload/test_youtube.py
+++ b/src/freeseer/tests/frontend/upload/test_youtube.py
@@ -21,10 +21,11 @@
 
 # For support, questions, suggestions or any other inquiries, visit:
 # http://wiki.github.com/Freeseer/freeseer/
-
+import os
 import mock
 import sys
 import unittest
+import pytest
 from StringIO import StringIO
 
 from freeseer.framework.youtube import Response
@@ -33,103 +34,31 @@ from freeseer.tests.framework.test_youtube import TestYoutubeService
 
 
 class TestYoutubeFrontend(unittest.TestCase):
+    TEST_RESPONSE = {
+        "id": "test",
+        "status": "test",
+        "content": "test",
+    }
+
     def setUp(self):
         """Stardard init method: runs before each test_* method"""
-        self.test_response = {
-            "id": "test",
-            "status": "test",
-            "content": "test"
-        }
         self.saved_stdout = sys.stdout
         self.out = StringIO()
 
-    def test_handle_response_success(self):
-        """Test Response.SUCCESS"""
-        expected = "The file was successfully uploaded with video id: {}".format(self.test_response['id'])
-        try:
-            sys.stdout = self.out
-            youtube.handle_response(Response.SUCCESS, self.test_response)
-            output = self.out.getvalue().strip()
-            self.assertEqual(expected, output)
-        finally:
-            sys.stdout = self.saved_stdout
-
-    def test_handle_response_failure(self):
-        """Test Response.UNEXPECTED_FAILURE"""
-        expected = "The file failed to upload with unexpected response: {}".format(self.test_response)
-        try:
-            sys.stdout = self.out
-            youtube.handle_response(Response.UNEXPECTED_FAILURE, self.test_response)
-            output = self.out.getvalue().strip()
-            self.assertEqual(expected, output)
-        finally:
-            sys.stdout = self.saved_stdout
-
-    def test_handle_response_unretriable(self):
-        """Test Response.UNRETRIABLE_ERROR"""
-        expected = "An unretriable HTTP error {} occurred:\n{}".format(self.test_response['status'], self.test_response['content'])
-        try:
-            sys.stdout = self.out
-            youtube.handle_response(Response.UNRETRIABLE_ERROR, self.test_response)
-            output = self.out.getvalue().strip()
-            self.assertEqual(expected, output)
-        finally:
-            sys.stdout = self.saved_stdout
-
-    def test_handle_response_max_retries(self):
-        """Test Response.MAX_RETRIES_REACHED"""
-        expected = "The maximum number of retries has been reached"
-        try:
-            sys.stdout = self.out
-            youtube.handle_response(Response.MAX_RETRIES_REACHED, self.test_response)
-            output = self.out.getvalue().strip()
-            self.assertEqual(expected, output)
-        finally:
-            sys.stdout = self.saved_stdout
-
-    def test_handle_response_token_error(self):
-        """Test Response.ACCESS_TOKEN_ERROR"""
-        expected = "The access token has expired or been revoked, please run python -m freeseer config youtube"
-        try:
-            sys.stdout = self.out
-            youtube.handle_response(Response.ACCESS_TOKEN_ERROR, self.test_response)
-            output = self.out.getvalue().strip()
-            self.assertEqual(expected, output)
-        finally:
-            sys.stdout = self.saved_stdout
-
     def test_get_defaults(self):
         """Test get_defaults, should always return a dict"""
-        self.assertTrue(youtube.get_defaults())
-
-    def test_upload_missing_token_file(self):
-        """Test missing token file on upload"""
-        token_path = "/path/that/does/not/exist"
-        expected = "{} does not exist, please specify a valid token file".format(token_path)
-        try:
-            sys.stdout = self.out
-            youtube.upload([], token_path, False)
-            output = self.out.getvalue().strip()
-            self.assertEqual(expected, output)
-        finally:
-            sys.stdout = self.saved_stdout
-
-    def test_upload_nothing_to_upload(self):
-        """Test nothing to upload"""
-        # Just pass a filepath that exists
-        token_path = TestYoutubeService.SAMPLE_VIDEO
-        expected = "Nothing to upload"
-        try:
-            sys.stdout = self.out
-            youtube.upload([], token_path, False)
-            output = self.out.getvalue().strip()
-            self.assertEqual(expected, output)
-        finally:
-            sys.stdout = self.saved_stdout
+        home = os.getenv('HOME')
+        expected = {
+            'client_secrets': '{}/.freeseer/client_secrets.json'.format(home),
+            'video_directory': '{}/Videos'.format(home),
+            'oauth2_token': '{}/.freeseer/oauth2_token.json'.format(home)
+        }
+        actual = youtube.get_defaults()
+        self.assertDictEqual(actual, expected)
 
     def test_prompt_user_not_yes(self):
         """Test output prompting user if they want to upload (assume yes was not specified)"""
-        test_videos = set(["v1", "v2", "v3"])
+        test_videos = {"v1", "v2", "v3"}
         expected = "Found videos:\n"
         joined = "\n".join(test_videos)
         expected += joined
@@ -144,4 +73,39 @@ class TestYoutubeFrontend(unittest.TestCase):
 
     def test_prompt_user_yes(self):
         """Test assume yes (assume yes was not specified)"""
-        self.assertTrue(youtube.prompt_user(set(["v1", "v2", "v3"]), confirmation=True))
+        self.assertTrue(youtube.prompt_user({"v1", "v2", "v3"}, confirmation=True))
+
+
+@pytest.mark.parametrize("expected, path", [
+    ("/path/that/does/not/exist does not exist, please specify a valid token file", "/path/that/does/not/exist"),
+    ("Nothing to upload", TestYoutubeService.SAMPLE_VIDEO),
+])
+def test_upload(capsys, expected, path):
+    """
+    Test the responses from the upload test cases.
+    """
+    youtube.upload([], path, False)
+    out, err = capsys.readouterr()
+    assert expected == out.strip()
+
+
+@pytest.mark.parametrize("expected, response", [
+    ("The file was successfully uploaded with video id: {}".format(TestYoutubeFrontend.TEST_RESPONSE['id']),
+     Response.SUCCESS),
+    ("The file failed to upload with unexpected response: {}".format(TestYoutubeFrontend.TEST_RESPONSE),
+     Response.UNEXPECTED_FAILURE),
+    ("An unretriable HTTP error {} occurred:\n{}".format(TestYoutubeFrontend.TEST_RESPONSE['status'],
+                                                         TestYoutubeFrontend.TEST_RESPONSE['content']),
+     Response.UNRETRIABLE_ERROR),
+    ("The maximum number of retries has been reached",
+     Response.MAX_RETRIES_REACHED),
+    ("The access token has expired or been revoked, please run python -m freeseer config youtube",
+     Response.ACCESS_TOKEN_ERROR),
+])
+def test_handle_response(capsys, expected, response):
+    """
+    Test the actual response vs the expected response from response_test_cases.
+    """
+    youtube.handle_response(response, TestYoutubeFrontend.TEST_RESPONSE)
+    out, err = capsys.readouterr()
+    assert expected == out.strip()


### PR DESCRIPTION
Refactoring tests as per the suggestions in #517.
- Comparing expected sample video metadata to metadata retrieved from video file.
- Tests to use parametrized test functions.

Closes #562 
