### PR TITLE
Added titles to popup dialogs in ConfigTool

### DIFF
--- a/src/freeseer/framework/plugin.py
+++ b/src/freeseer/framework/plugin.py
@@ -335,7 +335,7 @@ class IBackendPlugin(IPlugin):
             self.widget_load_config(self.plugman)
 
         if widget is not None:
-            self.gui.show_plugin_widget_dialog(widget)
+            self.gui.show_plugin_widget_dialog(widget, self.name)
 
     def get_widget(self):
         """

--- a/src/freeseer/frontend/configtool/configtool.py
+++ b/src/freeseer/frontend/configtool/configtool.py
@@ -528,7 +528,7 @@ class ConfigToolApp(FreeseerApp):
 
         return plugins
 
-    def show_plugin_widget_dialog(self, widget):
+    def show_plugin_widget_dialog(self, widget, name):
         """Shows the configuration dialog for a plugin."""
         self.dialog = QtGui.QDialog(self)
 
@@ -540,6 +540,7 @@ class ConfigToolApp(FreeseerApp):
         self.dialog.closeButton = QtGui.QPushButton("Close")
         self.dialog_layout.addWidget(self.dialog.closeButton)
         self.connect(self.dialog.closeButton, QtCore.SIGNAL('clicked()'), self.dialog.close)
+        self.dialog.setWindowTitle('{} Setup'.format(name))
         self.dialog.setModal(True)
         self.dialog.show()
 


### PR DESCRIPTION
The setup dialogs in the recording tab of ConfigTool had the title "python". This has been changed to more accurately reflect the settings being changed.
