### PR TITLE
Configtool Update Recording Tab

### DIFF
--- a/src/freeseer/frontend/configtool/AVWidget.py
+++ b/src/freeseer/frontend/configtool/AVWidget.py
@@ -46,6 +46,17 @@ class AVWidget(QtGui.QWidget):
         self.setLayout(self.mainLayout)
 
         config_icon = QtGui.QIcon.fromTheme("preferences-system")
+        self.fontSize = self.font().pixelSize()
+        if self.fontSize == -1:
+            self.fontUnit = "pt"
+            self.fontSize = self.font().pointSize()
+        else:
+            self.fontUnit = "px"
+
+        self.boxStyle = "QGroupBox {{ font-weight: bold; font-size: {0} {1} }} ".format(
+            self.fontSize + 1, self.fontUnit)
+        self.BOX_WIDTH = 400
+        self.BOX_HEIGHT = 60
 
         #
         # Audio Input
@@ -57,7 +68,9 @@ class AVWidget(QtGui.QWidget):
         self.mainLayout.insertWidget(0, self.audioGroupBox)
 
         self.audioGroupBox.setCheckable(True)
-        self.audioGroupBox.setSizePolicy(QtGui.QSizePolicy.MinimumExpanding, QtGui.QSizePolicy.MinimumExpanding)
+        self.audioGroupBox.setSizePolicy(QtGui.QSizePolicy.Fixed, QtGui.QSizePolicy.Fixed)
+        self.audioGroupBox.setFixedSize(self.BOX_WIDTH, self.BOX_HEIGHT)
+        self.audioGroupBox.setStyleSheet(self.boxStyle)
 
         self.audioMixerLabel = QtGui.QLabel("Audio Mixer")
         self.audioMixerLabel.setSizePolicy(QtGui.QSizePolicy.Maximum, QtGui.QSizePolicy.Maximum)
@@ -82,7 +95,9 @@ class AVWidget(QtGui.QWidget):
         self.mainLayout.insertWidget(0, self.videoGroupBox)
 
         self.videoGroupBox.setCheckable(True)
-        self.videoGroupBox.setSizePolicy(QtGui.QSizePolicy.MinimumExpanding, QtGui.QSizePolicy.MinimumExpanding)
+        self.videoGroupBox.setSizePolicy(QtGui.QSizePolicy.Fixed, QtGui.QSizePolicy.Fixed)
+        self.videoGroupBox.setFixedSize(self.BOX_WIDTH, self.BOX_HEIGHT)
+        self.videoGroupBox.setStyleSheet(self.boxStyle)
 
         self.videoMixerLabel = QtGui.QLabel("Video Mixer")
         self.videoMixerLabel.setSizePolicy(QtGui.QSizePolicy.Maximum, QtGui.QSizePolicy.Maximum)
@@ -98,31 +113,6 @@ class AVWidget(QtGui.QWidget):
         self.videoLayout.addWidget(self.videoMixerSetupPushButton, 0, 2)
 
         #
-        # Record to File
-        #
-
-        self.fileLayout = QtGui.QGridLayout()
-        self.fileGroupBox = QtGui.QGroupBox("Record to File")
-        self.fileGroupBox.setLayout(self.fileLayout)
-        self.mainLayout.insertWidget(0, self.fileGroupBox)
-
-        self.fileGroupBox.setCheckable(True)
-        self.fileGroupBox.setSizePolicy(QtGui.QSizePolicy.MinimumExpanding, QtGui.QSizePolicy.MinimumExpanding)
-
-        self.fileLabel = QtGui.QLabel("File Format")
-        self.fileLabel.setSizePolicy(QtGui.QSizePolicy.Maximum, QtGui.QSizePolicy.Maximum)
-        self.fileComboBox = QtGui.QComboBox()
-        self.fileLabel.setBuddy(self.fileComboBox)
-        self.fileSetupPushButton = QtGui.QToolButton()
-        self.fileSetupPushButton.setText("Setup")
-        self.fileSetupPushButton.setIcon(config_icon)
-        self.fileSetupPushButton.setSizePolicy(QtGui.QSizePolicy.Maximum, QtGui.QSizePolicy.Maximum)
-        self.fileSetupPushButton.setToolButtonStyle(QtCore.Qt.ToolButtonIconOnly)
-        self.fileLayout.addWidget(self.fileLabel, 0, 0)
-        self.fileLayout.addWidget(self.fileComboBox, 0, 1)
-        self.fileLayout.addWidget(self.fileSetupPushButton, 0, 2)
-
-        #
         # Record to Stream
         #
 
@@ -132,7 +122,9 @@ class AVWidget(QtGui.QWidget):
         self.mainLayout.insertWidget(0, self.streamGroupBox)
 
         self.streamGroupBox.setCheckable(True)
-        self.streamGroupBox.setSizePolicy(QtGui.QSizePolicy.MinimumExpanding, QtGui.QSizePolicy.MinimumExpanding)
+        self.streamGroupBox.setSizePolicy(QtGui.QSizePolicy.Fixed, QtGui.QSizePolicy.Fixed)
+        self.streamGroupBox.setFixedSize(self.BOX_WIDTH, self.BOX_HEIGHT)
+        self.streamGroupBox.setStyleSheet(self.boxStyle)
 
         self.streamLabel = QtGui.QLabel("Stream Format")
         self.streamLabel.setSizePolicy(QtGui.QSizePolicy.Maximum, QtGui.QSizePolicy.Maximum)
@@ -146,6 +138,48 @@ class AVWidget(QtGui.QWidget):
         self.streamLayout.addWidget(self.streamLabel, 0, 0)
         self.streamLayout.addWidget(self.streamComboBox, 0, 1)
         self.streamLayout.addWidget(self.streamSetupPushButton, 0, 2)
+
+        #
+        # Record to File
+        #
+
+        self.fileLayout = QtGui.QGridLayout()
+        self.fileGroupBox = QtGui.QGroupBox("Record to File")
+        self.fileGroupBox.setLayout(self.fileLayout)
+        self.mainLayout.insertWidget(0, self.fileGroupBox)
+
+        self.fileGroupBox.setCheckable(True)
+        self.fileGroupBox.setSizePolicy(QtGui.QSizePolicy.Fixed, QtGui.QSizePolicy.Fixed)
+        self.fileGroupBox.setFixedSize(self.BOX_WIDTH, self.BOX_HEIGHT + 40)
+        self.fileGroupBox.setStyleSheet(self.boxStyle)
+
+        self.fileDirLabel = QtGui.QLabel("Record Directory")
+        self.fileDirLineEdit = QtGui.QLineEdit()
+        self.fileDirLabel.setBuddy(self.fileDirLineEdit)
+        self.fileDirPushButton = QtGui.QPushButton("Browse...")
+        self.fileLayout.addWidget(self.fileDirLabel, 0, 0)
+        self.fileLayout.addWidget(self.fileDirLineEdit, 0, 1)
+        self.fileLayout.addWidget(self.fileDirPushButton, 0, 2)
+
+        self.fileLabel = QtGui.QLabel("File Format")
+        self.fileLabel.setSizePolicy(QtGui.QSizePolicy.Maximum, QtGui.QSizePolicy.Maximum)
+        self.fileComboBox = QtGui.QComboBox()
+        self.fileLabel.setBuddy(self.fileComboBox)
+        self.fileSetupPushButton = QtGui.QToolButton()
+        self.fileSetupPushButton.setText("Setup")
+        self.fileSetupPushButton.setIcon(config_icon)
+        self.fileSetupPushButton.setSizePolicy(QtGui.QSizePolicy.Maximum, QtGui.QSizePolicy.Maximum)
+        self.fileSetupPushButton.setToolButtonStyle(QtCore.Qt.ToolButtonIconOnly)
+        self.fileLayout.addWidget(self.fileLabel, 1, 0)
+        self.fileLayout.addWidget(self.fileComboBox, 1, 1)
+        self.fileLayout.addWidget(self.fileSetupPushButton, 1, 2)
+
+        # Blank line
+        self.mainLayout.insertSpacerItem(0, QtGui.QSpacerItem(0, self.fontSize * 2))
+        # Heading
+        self.title = QtGui.QLabel(u"{0} Recording {1}".format(u'<h1>', u'</h1>'))
+        self.mainLayout.insertWidget(0, self.title)
+
 
 if __name__ == "__main__":
     import sys

--- a/src/freeseer/frontend/configtool/ConfigToolWidget.py
+++ b/src/freeseer/frontend/configtool/ConfigToolWidget.py
@@ -89,6 +89,7 @@ class ConfigToolWidget(QtGui.QWidget):
         # Right panel
         #
         self.rightPanelWidget = QtGui.QWidget()
+        self.rightPanelWidget.setSizePolicy(QtGui.QSizePolicy.MinimumExpanding, QtGui.QSizePolicy.MinimumExpanding)
         self.mainLayout.addWidget(self.rightPanelWidget)
 
 if __name__ == "__main__":

--- a/src/freeseer/frontend/configtool/GeneralWidget.py
+++ b/src/freeseer/frontend/configtool/GeneralWidget.py
@@ -44,17 +44,26 @@ class GeneralWidget(QtGui.QWidget):
         self.mainLayout.addStretch(0)
         self.setLayout(self.mainLayout)
 
+        self.fontSize = self.font().pixelSize()
+        if self.fontSize == -1:
+            self.fontUnit = "pt"
+            self.fontSize = self.font().pointSize()
+        else:
+            self.fontUnit = "px"
+        self.boxStyle = "QGroupBox {{ font-weight: bold; font-size: {0} {1} }} ".format(
+            self.fontSize + 1, self.fontUnit)
         #
         # General
         #
 
-        self.MiscLayout = QtGui.QVBoxLayout()
-        self.MiscGroupBox = QtGui.QGroupBox("General")
-        self.MiscGroupBox.setLayout(self.MiscLayout)
-        self.mainLayout.insertWidget(0, self.MiscGroupBox)
+        self.miscLayout = QtGui.QVBoxLayout()
+        self.miscGroupBox = QtGui.QGroupBox("General")
+        self.miscGroupBox.setLayout(self.miscLayout)
+        self.miscGroupBox.setStyleSheet(self.boxStyle)
+        self.mainLayout.insertWidget(0, self.miscGroupBox)
 
         self.languageLayout = QtGui.QHBoxLayout()
-        self.MiscLayout.addLayout(self.languageLayout)
+        self.miscLayout.addLayout(self.languageLayout)
         self.languageLabel = QtGui.QLabel("Default Language")
         self.languageComboBox = QtGui.QComboBox()
         self.languageComboBox.setContextMenuPolicy(QtCore.Qt.ActionsContextMenu)
@@ -62,19 +71,8 @@ class GeneralWidget(QtGui.QWidget):
         self.languageLayout.addWidget(self.languageLabel)
         self.languageLayout.addWidget(self.languageComboBox)
 
-        self.recordDirLayout = QtGui.QHBoxLayout()
-        self.MiscLayout.addLayout(self.recordDirLayout)
-
-        self.recordDirLabel = QtGui.QLabel("Record Directory")
-        self.recordDirLineEdit = QtGui.QLineEdit()
-        self.recordDirLabel.setBuddy(self.recordDirLineEdit)
-        self.recordDirPushButton = QtGui.QPushButton("...")
-        self.recordDirLayout.addWidget(self.recordDirLabel)
-        self.recordDirLayout.addWidget(self.recordDirLineEdit)
-        self.recordDirLayout.addWidget(self.recordDirPushButton)
-
         self.autoHideCheckBox = QtGui.QCheckBox("Enable Auto-Hide")
-        self.MiscLayout.addWidget(self.autoHideCheckBox)
+        self.miscLayout.addWidget(self.autoHideCheckBox)
 
 
 if __name__ == "__main__":

--- a/src/freeseer/frontend/configtool/configtool.py
+++ b/src/freeseer/frontend/configtool/configtool.py
@@ -120,8 +120,8 @@ class ConfigToolApp(FreeseerApp):
         # general tab connections
         #
         self.connect(self.generalWidget.languageComboBox, QtCore.SIGNAL('currentIndexChanged(int)'), self.set_default_language)
-        self.connect(self.generalWidget.recordDirPushButton, QtCore.SIGNAL('clicked()'), self.browse_video_directory)
-        self.connect(self.generalWidget.recordDirLineEdit, QtCore.SIGNAL('editingFinished()'), self.update_record_directory)
+        self.connect(self.avWidget.fileDirPushButton, QtCore.SIGNAL('clicked()'), self.browse_video_directory)
+        self.connect(self.avWidget.fileDirLineEdit, QtCore.SIGNAL('editingFinished()'), self.update_record_directory)
         self.connect(self.generalWidget.autoHideCheckBox, QtCore.SIGNAL('toggled(bool)'), self.toggle_autohide)
 
         #
@@ -196,15 +196,16 @@ class ConfigToolApp(FreeseerApp):
         #
         # GeneralWidget
         #
-        self.generalWidget.MiscGroupBox.setTitle(self.app.translate("ConfigToolApp", "Miscellaneous"))
+        self.generalWidget.miscGroupBox.setTitle(self.app.translate("ConfigToolApp", "Miscellaneous"))
         self.generalWidget.languageLabel.setText(self.app.translate("ConfigToolApp", "Default Language"))
-        self.generalWidget.recordDirLabel.setText(self.app.translate("ConfigToolApp", "Record Directory"))
         self.generalWidget.autoHideCheckBox.setText(self.app.translate("ConfigToolApp", "Enable Auto-Hide"))
         # --- End GeneralWidget
 
         #
         # AV Widget
         #
+        self.avWidget.title.setText(u"{0} {1} {2}".format(u'<h1>', self.app.translate("ConfigToolApp", "Recording"), u'</h1>'))
+
         self.avWidget.audioGroupBox.setTitle(self.app.translate("ConfigToolApp", "Audio Input"))
         self.avWidget.audioMixerLabel.setText(self.app.translate("ConfigToolApp", "Audio Mixer"))
         self.avWidget.audioMixerSetupPushButton.setToolTip(self.app.translate("ConfigToolApp", "Setup"))
@@ -214,6 +215,8 @@ class ConfigToolApp(FreeseerApp):
         self.avWidget.videoMixerSetupPushButton.setToolTip(self.app.translate("ConfigToolApp", "Setup"))
 
         self.avWidget.fileGroupBox.setTitle(self.app.translate("ConfigToolApp", "Record to File"))
+        self.avWidget.fileDirLabel.setText(self.app.translate("ConfigToolApp", "Record Directory"))
+        self.avWidget.fileDirPushButton.setText("{}...".format(self.app.translate("ConfigToolApp", "Browse")))
         self.avWidget.fileLabel.setText(self.app.translate("ConfigToolApp", "File Format"))
         self.avWidget.fileSetupPushButton.setToolTip(self.app.translate("ConfigToolApp", "Setup"))
 
@@ -275,9 +278,6 @@ class ConfigToolApp(FreeseerApp):
         i = self.generalWidget.languageComboBox.findData(self.config.default_language)
         self.generalWidget.languageComboBox.setCurrentIndex(i)
 
-        # Recording Directory Settings
-        self.generalWidget.recordDirLineEdit.setText(self.config.videodir)
-
         # Load Auto Hide Settings
         if self.config.auto_hide:
             self.generalWidget.autoHideCheckBox.setChecked(True)
@@ -290,18 +290,18 @@ class ConfigToolApp(FreeseerApp):
         self.config.save()
 
     def browse_video_directory(self):
-        directory = self.generalWidget.recordDirLineEdit.text()
+        directory = self.avWidget.fileDirLineEdit.text()
 
         newDir = QtGui.QFileDialog.getExistingDirectory(self, "Select Video Directory", directory)
         if newDir == "":
             newDir = directory
 
         videodir = os.path.abspath(str(newDir))
-        self.generalWidget.recordDirLineEdit.setText(videodir)
-        self.generalWidget.recordDirLineEdit.emit(QtCore.SIGNAL("editingFinished()"))
+        self.avWidget.fileDirLineEdit.setText(videodir)
+        self.avWidget.fileDirLineEdit.emit(QtCore.SIGNAL("editingFinished()"))
 
     def update_record_directory(self):
-        self.config.videodir = str(self.generalWidget.recordDirLineEdit.text())
+        self.config.videodir = str(self.avWidget.fileDirLineEdit.text())
         self.config.save()
 
     def toggle_autohide(self, state):
@@ -357,6 +357,9 @@ class ConfigToolApp(FreeseerApp):
             if plugin.plugin_object.get_name() == self.config.videomixer:
                 self.avWidget.videoMixerComboBox.setCurrentIndex(n)
             n += 1
+
+        # Recording Directory Settings
+        self.avWidget.fileDirLineEdit.setText(self.config.videodir)
 
         #
         # Set up File Format

--- a/src/freeseer/frontend/qtcommon/AboutWidget.py
+++ b/src/freeseer/frontend/qtcommon/AboutWidget.py
@@ -76,18 +76,18 @@ class AboutWidget(QWidget):
         icon.addPixmap(QPixmap(_fromUtf8(":/freeseer/logo.png")), QIcon.Normal, QIcon.Off)
         self.setWindowIcon(icon)
 
-        self.mainlayout = QGridLayout()
-        self.setLayout(self.mainlayout)
+        self.mainLayout = QGridLayout()
+        self.setLayout(self.mainLayout)
 
         # Left top side of grid, Logo
         self.logo = QLabel("Logo")
         self.logo.setPixmap(QPixmap(_fromUtf8(":/freeseer/logo.png")))
-        self.mainlayout.addWidget(self.logo, 0, 0)
+        self.mainLayout.addWidget(self.logo, 0, 0)
 
         # Right top side of grid, Infos
         self.aboutInfo = QLabel("About Info", openExternalLinks=True)
         self.aboutInfo.setWordWrap(True)
-        self.mainlayout.addWidget(self.aboutInfo, 0, 1)
+        self.mainLayout.addWidget(self.aboutInfo, 0, 1)
 
         # Right bottom side of grid, Buttons
         self.buttonsLayout = QHBoxLayout()
@@ -98,7 +98,7 @@ class AboutWidget(QWidget):
         self.buttonsLayout.insertWidget(1, self.issueButton)
         self.buttonsLayout.insertWidget(2, self.contactButton)
 
-        self.mainlayout.addLayout(self.buttonsLayout, 2, 1)
+        self.mainLayout.addLayout(self.buttonsLayout, 2, 1)
 
         self.connect(self.docsButton, SIGNAL('clicked()'), self.openDocsUrl)
         self.connect(self.issueButton, SIGNAL('clicked()'), self.openNewIssueUrl)
@@ -125,7 +125,7 @@ class AboutWidget(QWidget):
                     "version 3. This software is provided 'as-is',without any express or implied warranty. In "
                     "no event will the authors be held liable for any damages arising from the use of this software.")
 
-        self.aboutInfoString = u'<h1>' + NAME + u'</h1>' + \
+        self.aboutInfoString = u'<h1>' + NAME.capitalize() + u'</h1>' + \
             u'<br><b>' + self.uiTranslator.translate("AboutDialog", "Version") + ": " + __version__ + u'</b>' + \
             u'<p>' + self.descriptionString + u'</p>' + \
             u'<p>' + self.copyrightString + u'</p>' + \

--- a/src/freeseer/frontend/qtcommon/languages/tr_ar_EG.ts
+++ b/src/freeseer/frontend/qtcommon/languages/tr_ar_EG.ts
@@ -131,6 +131,11 @@
         <translation>التسجيل</translation>
     </message>
     <message>
+        <location filename="../../configtool/configtool.py" line="204"/>
+        <source>Recording</source>
+        <translation>التسجيل</translation>
+    </message>
+    <message>
         <location filename="../../configtool/configtool.py" line="208"/>
         <source>Audio Input</source>
         <translation type="unfinished"></translation>
@@ -153,6 +158,11 @@
     <message>
         <location filename="../../configtool/configtool.py" line="217"/>
         <source>File Format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../configtool/configtool.py" line="218"/>
+        <source>Browse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/freeseer/frontend/qtcommon/languages/tr_de_DE.ts
+++ b/src/freeseer/frontend/qtcommon/languages/tr_de_DE.ts
@@ -131,6 +131,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../configtool/configtool.py" line="204"/>
+        <source>Recording</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../configtool/configtool.py" line="208"/>
         <source>Audio Input</source>
         <translation>Audioeingang</translation>
@@ -153,6 +158,11 @@
     <message>
         <location filename="../../configtool/configtool.py" line="217"/>
         <source>File Format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../configtool/configtool.py" line="218"/>
+        <source>Browse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/freeseer/frontend/qtcommon/languages/tr_en_US.ts
+++ b/src/freeseer/frontend/qtcommon/languages/tr_en_US.ts
@@ -132,6 +132,11 @@
         <translation>Recording</translation>
     </message>
     <message>
+        <location filename="../../configtool/configtool.py" line="204"/>
+        <source>Recording</source>
+        <translation>Recording</translation>
+    </message>
+    <message>
         <location filename="../../configtool/configtool.py" line="208"/>
         <source>Audio Input</source>
         <translation>Audio Input</translation>
@@ -155,6 +160,11 @@
         <location filename="../../configtool/configtool.py" line="217"/>
         <source>File Format</source>
         <translation>File Format</translation>
+    </message>
+    <message>
+        <location filename="../../configtool/configtool.py" line="218"/>
+        <source>Browse</source>
+        <translation>Browse</translation>
     </message>
     <message>
         <location filename="../../configtool/configtool.py" line="220"/>

--- a/src/freeseer/frontend/qtcommon/languages/tr_fr_CA.ts
+++ b/src/freeseer/frontend/qtcommon/languages/tr_fr_CA.ts
@@ -131,6 +131,11 @@
         <translation>Enregistrement</translation>
     </message>
     <message>
+        <location filename="../../configtool/configtool.py" line="204"/>
+        <source>Recording</source>
+        <translation>Enregistrement</translation>
+    </message>
+    <message>
         <location filename="../../configtool/configtool.py" line="208"/>
         <source>Audio Input</source>
         <translation>Entrée Audio</translation>
@@ -153,6 +158,11 @@
     <message>
         <location filename="../../configtool/configtool.py" line="217"/>
         <source>File Format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../configtool/configtool.py" line="218"/>
+        <source>Browse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/freeseer/frontend/qtcommon/languages/tr_ja.ts
+++ b/src/freeseer/frontend/qtcommon/languages/tr_ja.ts
@@ -131,6 +131,11 @@
         <translation>レコーディング</translation>
     </message>
     <message>
+        <location filename="../../configtool/configtool.py" line="204"/>
+        <source>Recording</source>
+        <translation>レコーディング</translation>
+    </message>
+    <message>
         <location filename="../../configtool/configtool.py" line="208"/>
         <source>Audio Input</source>
         <translation>オーディオ入力</translation>
@@ -153,6 +158,11 @@
     <message>
         <location filename="../../configtool/configtool.py" line="217"/>
         <source>File Format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../configtool/configtool.py" line="218"/>
+        <source>Browse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/freeseer/frontend/qtcommon/languages/tr_nl_NL.ts
+++ b/src/freeseer/frontend/qtcommon/languages/tr_nl_NL.ts
@@ -131,6 +131,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../configtool/configtool.py" line="204"/>
+        <source>Recording</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../configtool/configtool.py" line="208"/>
         <source>Audio Input</source>
         <translation type="unfinished"></translation>
@@ -153,6 +158,11 @@
     <message>
         <location filename="../../configtool/configtool.py" line="217"/>
         <source>File Format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../configtool/configtool.py" line="218"/>
+        <source>Browse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/freeseer/frontend/qtcommon/languages/tr_sv_SE.ts
+++ b/src/freeseer/frontend/qtcommon/languages/tr_sv_SE.ts
@@ -131,6 +131,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../../configtool/configtool.py" line="204"/>
+        <source>Recording</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../../configtool/configtool.py" line="208"/>
         <source>Audio Input</source>
         <translation type="unfinished"></translation>
@@ -153,6 +158,11 @@
     <message>
         <location filename="../../configtool/configtool.py" line="217"/>
         <source>File Format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../configtool/configtool.py" line="218"/>
+        <source>Browse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/freeseer/frontend/qtcommon/languages/tr_zh_CN.ts
+++ b/src/freeseer/frontend/qtcommon/languages/tr_zh_CN.ts
@@ -131,6 +131,11 @@
         <translation>记录</translation>
     </message>
     <message>
+        <location filename="../../configtool/configtool.py" line="204"/>
+        <source>Recording</source>
+        <translation>记录</translation>
+    </message>
+    <message>
         <location filename="../../configtool/configtool.py" line="208"/>
         <source>Audio Input</source>
         <translation>音频输入</translation>
@@ -153,6 +158,11 @@
     <message>
         <location filename="../../configtool/configtool.py" line="217"/>
         <source>File Format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../configtool/configtool.py" line="218"/>
+        <source>Browse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/freeseer/frontend/qtcommon/languages/tr_zh_HK.ts
+++ b/src/freeseer/frontend/qtcommon/languages/tr_zh_HK.ts
@@ -131,6 +131,11 @@
         <translation>記錄</translation>
     </message>
     <message>
+        <location filename="../../configtool/configtool.py" line="204"/>
+        <source>Recording</source>
+        <translation>記錄</translation>
+    </message>
+    <message>
         <location filename="../../configtool/configtool.py" line="208"/>
         <source>Audio Input</source>
         <translation>音頻輸入</translation>
@@ -153,6 +158,11 @@
     <message>
         <location filename="../../configtool/configtool.py" line="217"/>
         <source>File Format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../configtool/configtool.py" line="218"/>
+        <source>Browse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>


### PR DESCRIPTION
fixes #540
- [x] Moved directory selection to recording tab
- [x] Added recording tab heading
- [x] Other refactoring (renaming variables to match style)
- [x] Replace directory edit button text with "Browse..."
- [x] Translation support for the various changes

![recording tab screenshot](https://cloud.githubusercontent.com/assets/5759678/4341547/53402794-403a-11e4-999d-2ee814fc753a.jpg)

Note: There is a slight alignment issue caused by these modifications in the General tab because of the way ConfigTool is setup, everything in the different tabs is right-aligned unless it is forced to be left-aligned by something like a QLineEdit.

![general tab screenshot](https://cloud.githubusercontent.com/assets/5759678/4341576/b77f0dce-403a-11e4-85db-7ccad3046136.jpg)
