### PR TITLE
Related to #432: Add instructions to Contribute docs on how to install requirements

### DIFF
--- a/docs/source/contribute/basics.rst
+++ b/docs/source/contribute/basics.rst
@@ -81,6 +81,13 @@ Forking and Cloning Freeseer
    .. tip:: The name ``upstream`` is by convention. You can use whatever name
      you prefer (e.g. ``mainstream`` or ``mothership``).
 
+4. You now have a cloned repository with two remotes, one named ``origin`` and
+   one named ``upstream`` (or whichever name you chose). To ensure that you have
+   all the necessary requirements to run and test Freeseer, use Pip to install
+   the requirements listed in ``requirements.txt`` and ``dev_requirements.txt``. ::
+   
+    $ pip install -r requirements.txt
+    $ pip install -r dev_requirements.txt
 
 Basic Workflow
 --------------


### PR DESCRIPTION
I added an instruction on how to install the requirements listed in requirements.txt and dev_requirements.txt. This seemed like a good idea, because it wasn't obvious to me at the beginning. There are some instructions on this subject in the Quick Start guide (http://freeseer.readthedocs.org/en/latest/quick-start.html) but they seem to be aimed at people installing Freeseer, rather than running it from the source. #432 seemed like the most relevant pre-existing issue to match this change.

EDIT: As I look at the commits, they seem to include some artifacts of my early experiments with Git, wherein I made changes directly to the master, frantically tried to undo my mistakes by making more mistakes, and didn't understand the difference between "merge" and "rebase" -- not totally sure how to change those at this point.
