### PR TITLE
Update command line section for config

### DIFF
--- a/docs/source/userguide/config/index.rst
+++ b/docs/source/userguide/config/index.rst
@@ -11,18 +11,76 @@ General
 Command line
 ------------
 
-The freeseer-config tool has a few command line options.
+There's currently two main configuration options:
 
 .. glossary::
 
-  ``--reset``
-    Remove the entire freeseer configuration directory.
+  ``freeseer config reset``
+    Wipes various contents of the ``~/.freeseer`` directory.
+    A fresh configuration is useful when encountering weird issues.
 
-  ``--reset-configuration``
-    Remove freeseer.conf and plugins.conf from the configuration directory.
+  ``freeseer config youtube``
+    For configuring Freeseer's YouTube Uploader.
+    The ``--client-secrets`` and ``--token`` options are used in the authentication process.
 
-  ``--reset-database``
-    Remove presentations.db from the configuration directory.
+The ``-h/--help`` option can be used for more info.
+
+.. code-block:: bash
+
+  $ freeseer config --help
+  usage: freeseer config [-h] {reset,youtube} ...
+
+  positional arguments:
+    {reset,youtube}
+      reset          Reset Freeseer configuration and database
+      youtube        Obtain OAuth2 token for Youtube access
+
+  optional arguments:
+    -h, --help       show this help message and exit
+
+.. code-block:: bash
+
+  $ freeseer config reset --help
+  usage: freeseer config reset [-h] [-p PROFILE] {all,configuration,database}
+
+  positional arguments:
+    {all,configuration,database}
+                          Reset's Freeseer (default: all)
+
+                                  Options:
+                                      all           - Reset's Freeseer (removes the Freeseer configuration directory)
+                                      configuration - Reset's Freeseer configuration (removes freeseer.conf and plugins.conf)
+                                      database      - Reset's Freeseer database (removes presentations.db)
+
+
+  optional arguments:
+    -h, --help            show this help message and exit
+    -p PROFILE, --profile PROFILE
+                          Profile to reset (Default: default)
+
+.. code-block:: bash
+
+  $ freeseer config youtube --help
+  usage: freeseer config youtube [-h] [--auth_host_name AUTH_HOST_NAME]
+                                [--noauth_local_webserver]
+                                [--auth_host_port [AUTH_HOST_PORT [AUTH_HOST_PORT ...]]]
+                                [--logging_level {DEBUG,INFO,WARNING,ERROR,CRITICAL}]
+                                [-c CLIENT_SECRETS] [-t TOKEN]
+
+  optional arguments:
+    -h, --help            show this help message and exit
+    --auth_host_name AUTH_HOST_NAME
+                          Hostname when running a local web server.
+    --noauth_local_webserver
+                          Do not run a local web server.
+    --auth_host_port [AUTH_HOST_PORT [AUTH_HOST_PORT ...]]
+                          Port web server should listen on.
+    --logging_level {DEBUG,INFO,WARNING,ERROR,CRITICAL}
+                          Set the logging level of detail.
+    -c CLIENT_SECRETS, --client-secrets CLIENT_SECRETS
+                          Path to client secrets file
+    -t TOKEN, --token TOKEN
+                          Location to save token file
 
 Plugins
 -------


### PR DESCRIPTION
The old version uses instructions for `freeseer-config`, like `--reset` etc, which isn't supported anymore.

Added some example help output because it's easier than describing all the commands and options.

![image](https://cloud.githubusercontent.com/assets/497458/4381863/fbb0d73a-437c-11e4-8314-1ab2d859d2b9.png)

Closes #595 
