### PR TITLE
Configtool About tab update

### DIFF
--- a/src/freeseer/frontend/configtool/ConfigToolWidget.py
+++ b/src/freeseer/frontend/configtool/ConfigToolWidget.py
@@ -47,6 +47,7 @@ class ConfigToolWidget(QtGui.QWidget):
         '''
         QtGui.QWidget.__init__(self, parent)
 
+        self.setMinimumSize(800, 400)
         self.mainLayout = QtGui.QHBoxLayout()
         self.setLayout(self.mainLayout)
 
@@ -57,25 +58,26 @@ class ConfigToolWidget(QtGui.QWidget):
         self.leftPanelLayout = QtGui.QVBoxLayout()
         self.mainLayout.addLayout(self.leftPanelLayout)
 
-        # About
         self.optionsTreeWidget = QtGui.QTreeWidget()
         self.optionsTreeWidget.setSizePolicy(QtGui.QSizePolicy.Maximum, QtGui.QSizePolicy.Minimum)
         self.optionsTreeWidget.setHeaderHidden(True)
         self.optionsTreeWidget.headerItem().setText(0, "1")
-        QtGui.QTreeWidgetItem(self.optionsTreeWidget)
-        self.optionsTreeWidget.topLevelItem(0).setText(0, "About")
 
         # General
         QtGui.QTreeWidgetItem(self.optionsTreeWidget)
-        self.optionsTreeWidget.topLevelItem(1).setText(0, "General")
+        self.optionsTreeWidget.topLevelItem(0).setText(0, "General")
 
         # AV
         QtGui.QTreeWidgetItem(self.optionsTreeWidget)
-        self.optionsTreeWidget.topLevelItem(2).setText(0, "AV Config")
+        self.optionsTreeWidget.topLevelItem(1).setText(0, "AV Config")
 
         # Plugins
         QtGui.QTreeWidgetItem(self.optionsTreeWidget)
-        self.optionsTreeWidget.topLevelItem(3).setText(0, "Plugins")
+        self.optionsTreeWidget.topLevelItem(2).setText(0, "Plugins")
+
+        # About
+        QtGui.QTreeWidgetItem(self.optionsTreeWidget)
+        self.optionsTreeWidget.topLevelItem(3).setText(0, "About")
 
         closeIcon = QtGui.QIcon.fromTheme("application-exit")
         self.closePushButton = QtGui.QPushButton("Close")

--- a/src/freeseer/frontend/configtool/configtool.py
+++ b/src/freeseer/frontend/configtool/configtool.py
@@ -156,7 +156,7 @@ class ConfigToolApp(FreeseerApp):
         self.retranslate()
 
         # Start off with displaying the General Settings
-        items = self.mainWidget.optionsTreeWidget.findItems(self.aboutString, QtCore.Qt.MatchExactly)
+        items = self.mainWidget.optionsTreeWidget.findItems(self.generalString, QtCore.Qt.MatchExactly)
         if len(items) > 0:
             item = items[0]
             self.mainWidget.optionsTreeWidget.setCurrentItem(item)
@@ -186,10 +186,10 @@ class ConfigToolApp(FreeseerApp):
         self.videoMixerString = self.app.translate("ConfigToolApp", "VideoMixer")
         self.outputString = self.app.translate("ConfigToolApp", "Output")
 
-        self.mainWidget.optionsTreeWidget.topLevelItem(0).setText(0, self.aboutString)
-        self.mainWidget.optionsTreeWidget.topLevelItem(1).setText(0, self.generalString)
-        self.mainWidget.optionsTreeWidget.topLevelItem(2).setText(0, self.avString)
-        self.mainWidget.optionsTreeWidget.topLevelItem(3).setText(0, self.pluginsString)
+        self.mainWidget.optionsTreeWidget.topLevelItem(0).setText(0, self.generalString)
+        self.mainWidget.optionsTreeWidget.topLevelItem(1).setText(0, self.avString)
+        self.mainWidget.optionsTreeWidget.topLevelItem(2).setText(0, self.pluginsString)
+        self.mainWidget.optionsTreeWidget.topLevelItem(3).setText(0, self.aboutString)
         self.mainWidget.closePushButton.setText(self.app.translate("ConfigToolApp", "Close"))
         # --- End ConfigToolWidget
 

--- a/src/freeseer/frontend/qtcommon/AboutWidget.py
+++ b/src/freeseer/frontend/qtcommon/AboutWidget.py
@@ -29,6 +29,7 @@ from PyQt4.QtCore import QString
 from PyQt4.QtCore import QTranslator
 from PyQt4.QtCore import QUrl
 from PyQt4.QtCore import SIGNAL
+from PyQt4.QtCore import Qt
 from PyQt4.QtGui import QDesktopServices
 from PyQt4.QtGui import QGridLayout
 from PyQt4.QtGui import QHBoxLayout
@@ -37,6 +38,7 @@ from PyQt4.QtGui import QLabel
 from PyQt4.QtGui import QPixmap
 from PyQt4.QtGui import QPushButton
 from PyQt4.QtGui import QWidget
+from PyQt4.QtGui import QSizePolicy
 
 try:
     _fromUtf8 = QString.fromUtf8
@@ -66,30 +68,39 @@ class AboutWidget(QWidget):
     def __init__(self, parent=None):
         QWidget.__init__(self, parent)
 
-        self.setMinimumSize(100, 400)
-
         self.current_language = "en_US"
         self.uiTranslator = QTranslator()
         self.uiTranslator.load(":/languages/tr_en_US.qm")
 
+        self.fontSize = self.font().pixelSize()
+        self.fontUnit = "px"
+        if self.fontSize == -1:  # Font is set as points, not pixels.
+            self.fontUnit = "pt"
+            self.fontSize = self.font().pointSize()
+
         icon = QIcon()
-        icon.addPixmap(QPixmap(_fromUtf8(":/freeseer/logo.png")), QIcon.Normal, QIcon.Off)
+        self.logoPixmap = QPixmap(_fromUtf8(":/freeseer/logo.png"))
+        icon.addPixmap(self.logoPixmap, QIcon.Normal, QIcon.Off)
         self.setWindowIcon(icon)
 
         self.mainLayout = QGridLayout()
         self.setLayout(self.mainLayout)
 
-        # Left top side of grid, Logo
+        # Logo
         self.logo = QLabel("Logo")
-        self.logo.setPixmap(QPixmap(_fromUtf8(":/freeseer/logo.png")))
-        self.mainLayout.addWidget(self.logo, 0, 0)
+        # To offset the logo so that it's to the right of the title
+        self.logo.setStyleSheet("QLabel {{ margin-left: {} {} }}"
+            .format(90 + (self.fontSize * 2.5), self.fontUnit))
+        self.logo.setPixmap(self.logoPixmap.scaledToHeight(80))
+        self.mainLayout.addWidget(self.logo, 0, 0, Qt.AlignTop)
 
-        # Right top side of grid, Infos
+        # Info
         self.aboutInfo = QLabel("About Info", openExternalLinks=True)
+        self.aboutInfo.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
         self.aboutInfo.setWordWrap(True)
-        self.mainLayout.addWidget(self.aboutInfo, 0, 1)
+        self.mainLayout.addWidget(self.aboutInfo, 0, 0)
 
-        # Right bottom side of grid, Buttons
+        # Buttons
         self.buttonsLayout = QHBoxLayout()
         self.issueButton = QPushButton("Report an issue")
         self.docsButton = QPushButton("Freeseer documentation")
@@ -98,7 +109,7 @@ class AboutWidget(QWidget):
         self.buttonsLayout.insertWidget(1, self.issueButton)
         self.buttonsLayout.insertWidget(2, self.contactButton)
 
-        self.mainLayout.addLayout(self.buttonsLayout, 2, 1)
+        self.mainLayout.addLayout(self.buttonsLayout, 2, 0)
 
         self.connect(self.docsButton, SIGNAL('clicked()'), self.openDocsUrl)
         self.connect(self.issueButton, SIGNAL('clicked()'), self.openNewIssueUrl)
@@ -126,7 +137,8 @@ class AboutWidget(QWidget):
                     "no event will the authors be held liable for any damages arising from the use of this software.")
 
         self.aboutInfoString = u'<h1>' + NAME.capitalize() + u'</h1>' + \
-            u'<br><b>' + self.uiTranslator.translate("AboutDialog", "Version") + ": " + __version__ + u'</b>' + \
+            u'<br><b>' + self.uiTranslator.translate("AboutDialog", "Version") + \
+            ": " + __version__ + u'</b>' + \
             u'<p>' + self.descriptionString + u'</p>' + \
             u'<p>' + self.copyrightString + u'</p>' + \
             u'<p><a href="' + URL + u'">' + URL + u'</a></p>' \

--- a/src/freeseer/tests/frontend/configtool/test_config_tool.py
+++ b/src/freeseer/tests/frontend/configtool/test_config_tool.py
@@ -76,8 +76,8 @@ class TestConfigToolApp(unittest.TestCase):
         del self.config_tool.app
         self.app.deleteLater()
 
-    def test_about_widget(self):
-        self.assertTrue(self.config_tool.currentWidget == self.config_tool.aboutWidget)
+    def test_default_widget(self):
+        self.assertTrue(self.config_tool.currentWidget == self.config_tool.generalWidget)
 
     def test_general_settings(self):
         '''


### PR DESCRIPTION
Updated the layout of the "About" tab to be more similar to that of the newly changed "Recording" tab.

Windows:
![about tab screenshot](https://cloud.githubusercontent.com/assets/5759678/4452270/38c14652-4844-11e4-8349-305fe83ce5a3.jpg)

Linux:
![about tab screenshot](https://cloud.githubusercontent.com/assets/5759678/4452278/56d02d48-4844-11e4-9784-d5827105f247.png)
