### PR TITLE
#571: Fix footer broken

### DIFF
--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -18,4 +18,5 @@
   | <a href="/sitemap.html">Sitemap</a>
   | <a href="https://github.com/Freeseer/freeseer/issues/new" target="_blank">Report an issue</a>
 </div>
+{{ super() }}
 {% endblock %}


### PR DESCRIPTION
According to [Sphinx document](http://sphinx-doc.org/templating.html), we have to call {{ super() }} in order to render extended template.
