### PR TITLE
Refactor recording api methods and fix logic

### DIFF
--- a/src/freeseer/framework/multimedia.py
+++ b/src/freeseer/framework/multimedia.py
@@ -40,10 +40,10 @@ log = logging.getLogger(__name__)
 
 
 class Multimedia:
-    NULL = 0
-    RECORD = 1
-    PAUSE = 2
-    STOP = 3
+    NULL = 'NULL'
+    RECORD = 'RECORD'
+    PAUSE = 'PAUSE'
+    STOP = 'STOP'
 
     def __init__(self, config, plugman, window_id=None, audio_feedback=None, cli=False):
         self.config = config

--- a/src/freeseer/frontend/controller/server.py
+++ b/src/freeseer/frontend/controller/server.py
@@ -35,6 +35,7 @@ def start_server(storage_file):
     Args:
         storage_file - name of storage file to which you are saving recordings
     """
+
     app.storage_file_path = storage_file
     app.run()
 

--- a/src/freeseer/tests/framework/test_multimedia.py
+++ b/src/freeseer/tests/framework/test_multimedia.py
@@ -71,7 +71,7 @@ class TestMultimedia(unittest.TestCase):
         self.assertEqual(self.multimedia.player.get_state()[1], gst.STATE_PAUSED)
 
     def test_current_state_is_not_stop(self):
-        self.multimedia.player.set_state(self.multimedia.NULL)  # set to NULL
+        self.multimedia.player.set_state(gst.STATE_NULL)
         self.multimedia.stop()
         self.assertNotEqual(self.multimedia.current_state, self.multimedia.STOP)
         self.assertEqual(self.multimedia.player.get_state()[1], gst.STATE_NULL)

--- a/src/freeseer/tests/frontend/controller/test_server.py
+++ b/src/freeseer/tests/frontend/controller/test_server.py
@@ -24,9 +24,8 @@
 
 import json
 import os
-import shutil
-import tempfile
-import unittest
+
+import pytest
 
 from freeseer import settings
 from freeseer.framework.config.profile import ProfileManager
@@ -35,7 +34,7 @@ from freeseer.framework.plugin import PluginManager
 from freeseer.frontend.controller import server
 
 
-class MockMedia():
+class MockMedia:
     def __init__(self):
         self.current_state = Multimedia.NULL
         self.num_times_record_called = 0
@@ -52,330 +51,269 @@ class MockMedia():
         self.num_times_stop_called += 1
 
 
-class TestServerApp(unittest.TestCase):
+class TestServerApp:
     '''
     Test cases for Server.
     '''
 
-    def setUp(self):
-        '''
-        Stardard init method: runs before each test_* method
-        '''
+    @pytest.fixture(scope='module')
+    def test_client(self):
         server.app.config['TESTING'] = True
         server.app.storage_file_path = "test_storage_file"
-        self.app = server.app.test_client()
-        self.recording = server.app.blueprints['recording']
+        return server.app.test_client()
 
-        # token call to fire configuration logic
-        self.app.get('/recordings')
-        print self.recording.record_config.videodir
+    @pytest.fixture(scope='function', autouse=True)
+    def recording(self, request, test_client, monkeypatch, tmpdir):
 
-        self.profile_manager = ProfileManager(tempfile.mkdtemp())
-        self.temp_video_dir = tempfile.mkdtemp()
-        self.recording.record_config.videodir = self.temp_video_dir
-        self.recording.record_profile = self.profile_manager.get('testing')
-        self.recording.record_config = self.recording.record_profile.get_config('freeseer.conf', settings.FreeseerConfig, ['Global'], read_only=True)
-        self.recording.record_plugin_manager = PluginManager(self.recording.record_profile)
-        self.recording.media_dict = {}
+        recording = server.app.blueprints['recording']
 
-        # mock media
-        self.mock_media_1 = MockMedia()
-        self.mock_media_2 = MockMedia()
+        monkeypatch.setattr(settings, 'configdir', str(tmpdir.mkdir('configdir')))
+        test_client.get('/recordings')
 
-        self.test_media_dict_1 = {}
-        filepath1 = os.path.join(self.recording.record_config.videodir, 'mock_media_1')
-        filepath2 = os.path.join(self.recording.record_config.videodir, 'mock_media_1')
-        self.test_media_dict_1[1] = {'media': self.mock_media_1, 'filename': 'mock_media_1', 'filepath': filepath1}
-        self.test_media_dict_1[2] = {'media': self.mock_media_2, 'filename': 'mock_media_2', 'filepath': filepath2}
+        profile_manager = ProfileManager(str(tmpdir.mkdir('profile')))
+        recording.profile = profile_manager.get('testing')
+        recording.config = recording.profile.get_config('freeseer.conf', settings.FreeseerConfig, ['Global'], read_only=True)
+        recording.config.videodir = str(tmpdir.mkdir('Videos'))
+        recording.plugin_manager = PluginManager(recording.profile)
 
-    def tearDown(self):
-        '''
-        Generic unittest.TestCase.tearDown()
-        '''
-        shutil.rmtree(self.profile_manager._base_folder)
-        shutil.rmtree(self.temp_video_dir)
-        del self.app
+        return recording
 
-    def test_get_all_recordings_empty_media_dict(self):
+    @pytest.fixture(scope='function')
+    def mock_media_dict(self, request, recording):
+        mock_media_1 = MockMedia()
+        mock_media_2 = MockMedia()
+
+        filepath1 = os.path.join(recording.config.videodir, 'mock_media_1')
+        filepath2 = os.path.join(recording.config.videodir, 'mock_media_2')
+
+        recording.media_info['1'] = {
+            'status': Multimedia.NULL,
+            'filename': 'mock_media_1',
+            'filepath': filepath1,
+        }
+        recording.media_info['2'] = {
+            'status': Multimedia.NULL,
+            'filename': 'mock_media_2',
+            'filepath': filepath2,
+        }
+
+        recording.media_dict = {
+            1: mock_media_1,
+            2: mock_media_2,
+        }
+
+        def clear_media():
+            recording.media_info.clear()
+            recording.media_dict = {}
+        request.addfinalizer(clear_media)
+
+        return recording.media_dict
+
+    def test_get_all_recordings_empty_media_dict(self, test_client):
         '''
         Tests GET request retrieving all recordings with from an empty media dict
         '''
-        response = self.app.get('/recordings')
+        response = test_client.get('/recordings')
         response_data = json.loads(response.data)
-        self.assertTrue('recordings' in response_data)
-        self.assertTrue(response_data['recordings'] == [])
+        assert response_data == {'recordings': []}
 
-    def test_get_nonexistent_recording_id(self):
+    def test_get_nonexistent_recording_id(self, test_client):
         '''
         Tests GET request retrieving non-existent recording
         '''
-        response = self.app.get('/recordings/1')
+        response = test_client.get('/recordings/1')
         response_data = json.loads(response.data)
-        self.assertEqual(response_data['error_message'], "recording id could not be found")
-        self.assertEqual(response_data['error_code'], 404)
-        self.assertEqual(response.status_code, 404)
+        assert response_data['error_code'] == 404
+        assert response.status_code == 404
 
-    def test_get_all_recordings(self):
+    def test_get_all_recordings(self, test_client, mock_media_dict):
         '''
         Tests GET request all recordings with 2 entries in media dict
         '''
-        self.recording.media_dict = self.test_media_dict_1
-        response = self.app.get('/recordings')
+        response = test_client.get('/recordings')
         response_data = json.loads(response.data)
-        self.assertTrue('recordings' in response_data)
-        self.assertTrue(response_data['recordings'] == [1, 2])
+        assert response_data == {'recordings': [1, 2]}
 
-    def test_get_recording_id(self):
+    def test_get_recording_id(self, test_client, mock_media_dict):
         '''
         Tests GET request specific valid recording
         '''
-        self.recording.media_dict = self.test_media_dict_1
-        response = self.app.get('/recordings/1')
+        response = test_client.get('/recordings/1')
         response_data = json.loads(response.data)
-        self.assertTrue('recordings' not in response_data)
-        self.assertTrue('filename' in response_data)
-        self.assertTrue('filesize' in response_data)
-        self.assertTrue('status' in response_data)
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response_data['filename'], 'mock_media_1')
-        self.assertEqual(response_data['filesize'], 'NA')
-        self.assertEqual(response_data['id'], 1)
-        self.assertEqual(response_data['status'], 'NULL')
+        assert response.status_code == 200
 
-    def test_get_invalid_recording_id(self):
+        assert response_data == {
+            'filename': 'mock_media_1',
+            'filesize': 'NA',
+            'id': 1,
+            'status': 'NULL',
+        }
+
+    def test_get_invalid_recording_id(self, test_client, mock_media_dict):
         '''
         Tests GET request with an invalid id (a non integer id)
         '''
-        self.recording.media_dict = self.test_media_dict_1
-        response = self.app.get('/recordings/abc')
-        self.assertEqual(response.status_code, 404)
+        response = test_client.get('/recordings/abc')
+        assert response.status_code == 404
 
-        response = self.app.get('/recordings/1.0')
-        self.assertEqual(response.status_code, 404)
+        response = test_client.get('/recordings/1.0')
+        assert response.status_code == 404
 
-    def test_patch_no_id(self):
+    def test_patch_no_id(self, test_client):
         '''
         Tests a PATCH request without a recording id
         '''
-        response = self.app.patch('/recordings')
-        self.assertEqual(response.status_code, 405)
+        response = test_client.patch('/recordings')
+        assert response.status_code == 405
 
-    def test_patch_nonexistant_id(self):
+    def test_patch_nonexistant_id(self, test_client, mock_media_dict):
         '''
         Tests a PATCH request with non-existant recording id
         '''
-        self.recording.media_dict = self.test_media_dict_1
-        response = self.app.patch('/recordings/100')
-        self.assertEqual(response.status_code, 404)
+        response = test_client.patch('/recordings/100', data={'command': 'start'})
+        assert response.status_code == 404
 
-    def test_patch_no_command(self):
+    def test_patch_no_command(self, test_client, mock_media_dict):
         '''
         Tests a PATCH request without a command
         '''
-        self.recording.media_dict = self.test_media_dict_1
-        response = self.app.patch('/recordings/1')
-        self.assertEqual(response.status_code, 400)
+        response = test_client.patch('/recordings/1')
+        assert response.status_code == 400
 
-    def test_patch_invalid_command(self):
+    def test_patch_invalid_command(self, test_client, mock_media_dict):
         '''
         Tests a Patch request with an invalid command
         '''
-        self.recording.media_dict = self.test_media_dict_1
-        data_to_send = {'command': 'invalid command'}
-        response = self.app.patch('/recordings/1', data=data_to_send)
-        self.assertEqual(response.status_code, 400)
+        response = test_client.patch('/recordings/1', data={'command': 'invalid command'})
+        assert response.status_code == 400
 
-    def test_patch_start(self):
+    @pytest.mark.parametrize("current_state", [Multimedia.NULL, Multimedia.PAUSE])
+    def test_patch_start(self, test_client, recording, mock_media_dict, current_state):
         '''
         Tests a Patch request to start a recording
         '''
-        self.mock_media_1.current_state = Multimedia.NULL
-        self.recording.media_dict = self.test_media_dict_1
-        data_to_send = {'command': 'start'}
-        response = self.app.patch('/recordings/1', data=data_to_send)
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(self.mock_media_1.num_times_record_called, 1)
+        mock_media_dict[1].current_state = current_state
+        response = test_client.patch('/recordings/1', data={'command': 'start'})
+        assert response.status_code == 200
+        assert mock_media_dict[1].num_times_record_called == 1
 
-        self.mock_media_1.num_times_record_called = 0
-        self.mock_media_1.current_state = Multimedia.PAUSE
-        self.recording.media_dict = self.test_media_dict_1
-        data_to_send = {'command': 'start'}
-        response = self.app.patch('/recordings/1', data=data_to_send)
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(self.mock_media_1.num_times_record_called, 1)
-
-    def test_patch_start_invalid(self):
+    @pytest.mark.parametrize("current_state", [Multimedia.STOP, Multimedia.RECORD])
+    def test_patch_start_invalid(self, test_client, mock_media_dict, current_state):
         '''
         Tests a Patch request to start a recording with an invalid media state
         '''
-        self.mock_media_1.current_state = Multimedia.STOP
-        self.recording.media_dict = self.test_media_dict_1
-        data_to_send = {'command': 'start'}
-        response = self.app.patch('/recordings/1', data=data_to_send)
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(self.mock_media_1.num_times_record_called, 0)
+        mock_media_dict[1].current_state = current_state
+        response = test_client.patch('/recordings/1', data={'command': 'start'})
+        assert response.status_code == 400
+        assert mock_media_dict[1].num_times_record_called == 0
 
-        self.mock_media_1.num_times_record_called = 0
-        self.mock_media_1.current_state = Multimedia.RECORD
-        self.recording.media_dict = self.test_media_dict_1
-        data_to_send = {'command': 'start'}
-        response = self.app.patch('/recordings/1', data=data_to_send)
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(self.mock_media_1.num_times_record_called, 0)
-
-    def test_patch_pause(self):
+    def test_patch_pause(self, test_client, mock_media_dict):
         '''
         Tests a Patch request to pause a recording
         '''
-        self.mock_media_1.current_state = Multimedia.RECORD
-        self.recording.media_dict = self.test_media_dict_1
-        data_to_send = {'command': 'pause'}
-        response = self.app.patch('/recordings/1', data=data_to_send)
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(self.mock_media_1.num_times_pause_called, 1)
+        mock_media_dict[1].current_state = Multimedia.RECORD
+        response = test_client.patch('/recordings/1', data={'command': 'pause'})
+        assert response.status_code == 200
+        assert mock_media_dict[1].num_times_pause_called == 1
 
-    def test_patch_pause_invalid(self):
+    @pytest.mark.parametrize("current_state", [Multimedia.NULL, Multimedia.PAUSE, Multimedia.STOP])
+    def test_patch_pause_invalid(self, test_client, mock_media_dict, current_state):
         '''
         Tests a Patch request to pause a recording with an invalid media state
         '''
-        self.mock_media_1.current_state = Multimedia.NULL
-        self.recording.media_dict = self.test_media_dict_1
-        data_to_send = {'command': 'pause'}
-        response = self.app.patch('/recordings/1', data=data_to_send)
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(self.mock_media_1.num_times_pause_called, 0)
+        mock_media_dict[1].current_state = current_state
+        response = test_client.patch('/recordings/1', data={'command': 'pause'})
+        assert response.status_code == 400
+        assert mock_media_dict[1].num_times_pause_called == 0
 
-        self.mock_media_1.current_state = Multimedia.PAUSE
-        self.recording.media_dict = self.test_media_dict_1
-        data_to_send = {'command': 'pause'}
-        response = self.app.patch('/recordings/1', data=data_to_send)
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(self.mock_media_1.num_times_pause_called, 0)
-
-        self.mock_media_1.current_state = Multimedia.STOP
-        self.recording.media_dict = self.test_media_dict_1
-        data_to_send = {'command': 'pause'}
-        response = self.app.patch('/recordings/1', data=data_to_send)
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(self.mock_media_1.num_times_pause_called, 0)
-
-    def test_patch_stop(self):
+    @pytest.mark.parametrize("current_state", [Multimedia.PAUSE, Multimedia.RECORD])
+    def test_patch_stop(self, test_client, mock_media_dict, current_state):
         '''
         Tests a Patch request to stop a recording
         '''
-        self.mock_media_1.current_state = Multimedia.RECORD
-        self.recording.media_dict = self.test_media_dict_1
-        data_to_send = {'command': 'stop'}
-        response = self.app.patch('/recordings/1', data=data_to_send)
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(self.mock_media_1.num_times_stop_called, 1)
+        mock_media_dict[1].current_state = current_state
+        response = test_client.patch('/recordings/1', data={'command': 'stop'})
+        assert response.status_code == 200
+        assert mock_media_dict[1].num_times_stop_called == 1
 
-        self.mock_media_1.num_times_stop_called = 0
-        self.mock_media_1.current_state = Multimedia.PAUSE
-        self.recording.media_dict = self.test_media_dict_1
-        data_to_send = {'command': 'stop'}
-        response = self.app.patch('/recordings/1', data=data_to_send)
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(self.mock_media_1.num_times_stop_called, 1)
-
-    def test_patch_stop_invalid(self):
+    @pytest.mark.parametrize("current_state", [Multimedia.STOP, Multimedia.NULL])
+    def test_patch_stop_invalid(self, test_client, mock_media_dict, current_state):
         '''
         Tests a Patch request to stop a recording with an invalid media state
         '''
-        self.mock_media_1.current_state = Multimedia.STOP
-        self.recording.media_dict = self.test_media_dict_1
-        data_to_send = {'command': 'stop'}
-        response = self.app.patch('/recordings/1', data=data_to_send)
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(self.mock_media_1.num_times_stop_called, 0)
+        mock_media_dict[1].current_state = current_state
+        response = test_client.patch('/recordings/1', data={'command': 'stop'})
+        assert response.status_code == 400
+        assert mock_media_dict[1].num_times_stop_called == 0
 
-        self.mock_media_1.num_times_stop_called = 0
-        self.mock_media_1.current_state = Multimedia.NULL
-        self.recording.media_dict = self.test_media_dict_1
-        data_to_send = {'command': 'stop'}
-        response = self.app.patch('/recordings/1', data=data_to_send)
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(self.mock_media_1.num_times_stop_called, 0)
-
-    def test_post_no_filename(self):
+    def test_post_no_filename(self, test_client):
         '''
         Tests a POST request without a filename
         '''
-        response = self.app.post('/recordings')
-        self.assertEqual(response.status_code, 400)
+        response = test_client.post('/recordings')
+        assert response.status_code == 400
 
-    def test_post_empty_filename(self):
+    def test_post_empty_filename(self, test_client):
         '''
         Tests a POST request with an empty filename
         '''
-        data_to_send = {'filename': ''}
-        response = self.app.post('/recordings', data=data_to_send)
-        self.assertEqual(response.status_code, 400)
+        response = test_client.post('/recordings', data={'filename': ''})
+        assert response.status_code == 400
 
-    def test_post_invalid_filename(self):
+    def test_post_invalid_filename(self, test_client):
         '''
         Tests a POST request with an invalid filename
         '''
-        data_to_send = {'filename': 'abc/123'}
-        response = self.app.post('/recordings', data=data_to_send)
-        self.assertEqual(response.status_code, 400)
+        response = test_client.post('/recordings', data={'filename': 'abc/123'})
+        assert response.status_code == 400
 
-    def test_post(self):
+    def test_post(self, test_client, recording):
         '''
         Tests a regular POST request
         '''
-        self.assertTrue(len(self.recording.media_dict.keys()) == 0)
-        data_to_send = {'filename': 'test'}
-        response = self.app.post('/recordings', data=data_to_send)
-        self.assertTrue(len(self.recording.media_dict.keys()) == 1)
-        self.assertEqual(response.status_code, 201)
-        self.assertEqual(self.recording.media_dict.keys(), [1])
-        self.assertEqual(self.recording.media_dict[1]['filename'], 'test.ogg')
+        assert len(recording.media_dict) == 0
+        response = test_client.post('/recordings', data={'filename': 'test'})
+        assert response.status_code == 201
+        assert recording.media_dict.keys() == [1]
+        assert recording.media_info['1']['filename'] == 'test.ogg'
 
-    def test_delete_no_recording_id(self):
+    def test_delete_no_recording_id(self, test_client):
         '''
         Tests a DELETE request without a provided recording id
         '''
-        response = self.app.delete('/recordings')
-        self.assertEqual(response.status_code, 405)
+        response = test_client.delete('/recordings')
+        assert response.status_code == 405
 
-    def test_delete_nonexistant_recording_id(self):
+    def test_delete_nonexistent_recording_id(self, test_client):
         '''
         Tests a DELETE request with a recording id that doesn't exist
         '''
-        response = self.app.delete('/recordings/100')
-        self.assertEqual(response.status_code, 404)
+        response = test_client.delete('/recordings/100')
+        assert response.status_code == 404
 
-    def test_delete_invalid_recording_id(self):
+    @pytest.mark.parametrize("invalid_id", ['abc', '1.0'])
+    def test_delete_invalid_recording_id(self, test_client, invalid_id):
         '''
         Tests a DELETE request with an invalid recording id
         '''
-        response = self.app.delete('/recordings/abc')
-        self.assertEqual(response.status_code, 404)
-        response = self.app.delete('/recordings/1.0')
-        self.assertEqual(response.status_code, 404)
+        response = test_client.delete('/recordings/{0}'.format(invalid_id))
+        assert response.status_code == 404
 
-    def test_delete_in_progress_recording(self):
+    @pytest.mark.parametrize("current_state", [Multimedia.RECORD, Multimedia.PAUSE])
+    def test_delete_in_progress_recording(self, test_client, recording, mock_media_dict, current_state):
         '''
         Tests a DELETE request for a recording that is paused or in progress
         '''
-        self.recording.media_dict = self.test_media_dict_1
 
         # delete a recording that is in the middle of recording
-        self.mock_media_1.current_state = Multimedia.RECORD
-        response = self.app.delete('/recordings/1')
-        self.assertEqual(response.status_code, 204)
-        self.assertEqual(self.mock_media_1.num_times_stop_called, 1)
-        self.assertEqual(self.recording.media_dict.keys(), [2])
+        mock_media_dict[1].current_state = current_state
+        del_media = mock_media_dict[1]
+        response = test_client.delete('/recordings/1')
+        assert response.status_code == 204
+        assert del_media.num_times_stop_called == 1
+        assert recording.media_dict.keys() == [2]
 
-        # delete a recording that is paused
-        self.mock_media_2.current_state = Multimedia.PAUSE
-        response = self.app.delete('/recordings/2')
-        self.assertEqual(response.status_code, 204)
-        self.assertEqual(self.mock_media_2.num_times_stop_called, 1)
-        self.assertEqual(self.recording.media_dict.keys(), [])
-
-    def test_delete_recording_id_and_file(self):
+    def test_delete_recording_id_and_file(self, test_client, recording, mock_media_dict):
         '''
         Tests a DELETE request where the recording has a specified file
         '''
@@ -383,24 +321,19 @@ class TestServerApp(unittest.TestCase):
         # setup - create the file to be deleted
         file_base_name = 'testDeleteFile'
         file_to_delete = file_base_name
-        file_to_delete_path = os.path.join(self.recording.record_config.videodir, file_to_delete)
-        counter = 1
-        while os.path.isfile(file_to_delete_path):
-            file_to_delete = file_base_name + str(counter)
-            file_to_delete_path = os.path.join(self.recording.record_config.videodir, file_to_delete)
-            counter += 1
+        file_to_delete_path = os.path.join(recording.config.videodir, file_to_delete)
         test_file = open(file_to_delete_path, 'a')
         test_file.close()
 
         # assert the file exists
-        self.assertTrue(os.path.isfile(file_to_delete_path))
+        assert os.path.isfile(file_to_delete_path)
 
-        # setup - set the file as the file for the Media instance
-        self.recording.media_dict[1] = {'media': self.mock_media_1, 'filename': file_to_delete, 'filepath': file_to_delete_path}
+        # set mock_media filepath to filepath of file to be deleted
+        recording.media_info['1']['filepath'] = file_to_delete_path
 
-        response = self.app.delete('/recordings/1')
-        self.assertEqual(response.status_code, 204)
-        self.assertEqual(self.recording.media_dict.keys(), [])
+        response = test_client.delete('/recordings/1')
+        assert response.status_code == 204
+        assert recording.media_dict.keys() == [2]
 
         # assert the file no longer exists
-        self.assertFalse(os.path.isfile(file_to_delete_path))
+        assert not os.path.isfile(file_to_delete_path)


### PR DESCRIPTION
Refactored code of recording api setup, teardown, and
endpoint functions.

Added a get_current_state_str() method to Multimedia to make some code
in recording api cleaner.

Fix to recording api logic determining next_id.
Fix to test_server.py teardown to undo patching to media_dict

closes #629
