### PR TITLE
Fixed #614 Change resolution for input Video

### DIFF
--- a/src/freeseer/plugins/videomixer/videopassthrough/widget.py
+++ b/src/freeseer/plugins/videomixer/videopassthrough/widget.py
@@ -26,6 +26,8 @@ http://wiki.github.com/Freeseer/freeseer/
 @author: Thanh Ha
 '''
 
+from collections import OrderedDict
+
 from PyQt4.QtCore import Qt
 from PyQt4.QtGui import QComboBox
 from PyQt4.QtGui import QFormLayout
@@ -38,6 +40,16 @@ from PyQt4.QtGui import QSpinBox
 from PyQt4.QtGui import QStackedWidget
 from PyQt4.QtGui import QToolButton
 from PyQt4.QtGui import QWidget
+
+
+resmap = OrderedDict([
+    ('No Scaling', (0, 0)),
+    ('240p', (320, 240)),
+    ('360p', (480, 360)),
+    ('480p', (640, 480)),
+    ('720p', (1280, 720)),
+    ('1080p', (1920, 1080)),
+])
 
 
 class ConfigWidget(QWidget):
@@ -87,6 +99,7 @@ class ConfigWidget(QWidget):
 
         self.videoscaleLabel = QLabel("Video Scale")
         self.videoscaleComboBox = QComboBox()
-        self.videoscaleComboBox.addItem("NOSCALE")
+        for scale in resmap:
+            self.videoscaleComboBox.addItem(scale)
         self.videoscaleComboBox.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Maximum)
         layout.addRow(self.videoscaleLabel, self.videoscaleComboBox)

--- a/src/freeseer/settings.py
+++ b/src/freeseer/settings.py
@@ -39,21 +39,8 @@ profile_manager = ProfileManager(os.path.join(configdir, 'profiles'))
 class FreeseerConfig(Config):
     """General Freeseer profile settings."""
 
-    resmap = {
-        # No Scaling
-        'default': '0x0',
-
-        # Scaling
-        '240p': '320x240',
-        '360p': '480x360',
-        '480p': '640x480',
-        '720p': '1280x720',
-        '1080p': '1920x1080'
-    }
-
     videodir = options.FolderOption('~/Videos', auto_create=True)
     auto_hide = options.BooleanOption(False)
-    resolution = options.ChoiceOption(resmap.keys(), 'default')
     enable_audio_recording = options.BooleanOption(True)
     enable_video_recording = options.BooleanOption(True)
     videomixer = options.StringOption('Video Passthrough')


### PR DESCRIPTION
Fixes #614
- Add more options for Video Passthrough Setting, which will change the output video resolution.

![default](https://cloud.githubusercontent.com/assets/5828044/4518433/e098dd04-4c8b-11e4-9422-781c8695115e.png)
