### PR TITLE
Fix #596: Switch docs to rtd theme

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -6,3 +6,4 @@ pep8==1.4.6
 pytest-cov==1.6
 pytest==2.5.2
 Sphinx<=1.2.3
+sphinx_rtd_theme

--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -1,16 +1,5 @@
 {% extends '!layout.html' %}
 
-{% block extrahead %} <!-- This block is used to add content to <head> tag. -->
-<style>
-  a:link {color:#3B5998}
-  a:visited {color:#005B81}
-  a:hover {color:#8A2BE2}
-  a:active {color:#E32E00}
-  div.footer {color:#E2F3CC; font-size: 80%;}
-  div.footer a {color:#E2F3CC}
-</style>
-{% endblock %}
-
 {% block footer %}
 <div class="footer">
   © 2013 FOSSLC

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,6 +13,7 @@
 
 import os
 import sys
+import sphinx_rtd_theme
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here.
@@ -96,7 +97,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'nature'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -104,7 +105,7 @@ html_theme = 'nature'
 #html_theme_options = {}
 
 # Add any paths that contain custom themes here, relative to this directory.
-#html_theme_path = []
+html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
@@ -115,7 +116,7 @@ html_theme = 'nature'
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
-html_logo = 'freeseer_logo.png'
+#html_logo = 'freeseer_logo.png'
 
 # The name of an image file (within the static path) to use as favicon of the
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32


### PR DESCRIPTION
Fix #596 

Completed:
-  [x] Added "sphinx_rtd_theme" to dev_requirements.txt
-  [x] Removed old styling from ./_template/layout.html
-  [x] Configured sphinx_rtd_theme in conf.py

To-Do:
- [ ] Display freeseer logo near next to the "Freeseer" title 
- [x] Use custom footer information (#621)
