### PR TITLE
Fix #628 Unload Input Source Problem

### DIFF
--- a/src/freeseer/framework/multimedia.py
+++ b/src/freeseer/framework/multimedia.py
@@ -349,6 +349,7 @@ class Multimedia:
 
             self.audiomixer.unlink(self.audio_tee)
             self.player.remove(self.audiomixer)
+        self.record_audio = False
 
     def load_videomixer(self, mixer, inputs):
         self.record_video = True
@@ -375,3 +376,4 @@ class Multimedia:
 
             self.videomixer.unlink(self.video_tee)
             self.player.remove(self.videomixer)
+        self.record_video = False


### PR DESCRIPTION
Now the user can load and unload video/audio input sources and record without closing the program.

This bug was caused because the flag variables self.record_audio and self.record_video are not cleared after a cycle of recording ends. So the program will try to unload the source even it has been unchecked.
This fix reset the variables by the end of recording so it will not influence the next one.
