### PR TITLE
Fixes #638 Record Region not checked after selecting region

### DIFF
--- a/src/freeseer/plugins/videoinput/desktop/__init__.py
+++ b/src/freeseer/plugins/videoinput/desktop/__init__.py
@@ -137,6 +137,10 @@ class DesktopLinuxSrc(IVideoInput):
         self.config.end_y = end_y
         self.config.save()
         log.debug('Area selector start: %sx%s end: %sx%s', start_x, start_y, end_x, end_y)
+        # Automatically check the "Record Region" button.
+        self.set_desktop_area()
+        self.widget.areaButton.setChecked(True)
+
         self.gui.show()
         self.widget.window().show()
 

--- a/src/freeseer/plugins/videoinput/desktop/widget.py
+++ b/src/freeseer/plugins/videoinput/desktop/widget.py
@@ -51,7 +51,7 @@ class ConfigWidget(QWidget):
         areaGroup = QHBoxLayout()
         self.areaLabel = QLabel("Record Region")
         self.areaButton = QRadioButton()
-        self.setAreaButton = QPushButton("Set")
+        self.setAreaButton = QPushButton("Select Region")
         areaGroup.addWidget(self.areaButton)
         areaGroup.addWidget(self.setAreaButton)
         layout.addRow(self.areaLabel, areaGroup)


### PR DESCRIPTION
- The Record Region button will be automatically checked
  after the user selecting a region to record.
- Rename the 'Set' button to 'Select Region'.
