### PR TITLE
Fix #623 - Add Quality selection options to ConfigTool for Audio/Video output

### DIFF
--- a/src/freeseer/framework/plugin.py
+++ b/src/freeseer/framework/plugin.py
@@ -249,6 +249,7 @@ class IBackendPlugin(IPlugin):
     os = []
 
     config_loaded = False
+    widget_config_loaded = False
 
     def __init__(self):
         IPlugin.__init__(self)
@@ -289,9 +290,9 @@ class IBackendPlugin(IPlugin):
         self.retranslate()  # Translate the UI
 
         # Only load configuration the first time the user opens widget
-        if not self.config_loaded:
+        if not self.widget_config_loaded:
             log.debug("%s loading configuration into widget.", self.name)
-            self.config_loaded = True
+            self.widget_config_loaded = True
             self.widget_load_config(self.plugman)
 
         if widget is not None:
@@ -299,6 +300,12 @@ class IBackendPlugin(IPlugin):
 
         if self.config is not None:
             self.config.save()
+
+    def get_config(self):
+        """Check if the config is loaded, if not then load it."""
+        if not self.config_loaded:
+            self.config_loaded = True
+            self.load_config(self.plugman)
 
     def get_widget(self):
         """
@@ -377,6 +384,9 @@ class IVideoInput(IBackendPlugin):
         """
         raise NotImplementedError
 
+    def get_resolution_pixels(self):
+        raise NotImplementedError
+
 
 class IVideoMixer(IBackendPlugin):
     CATEGORY = "VideoMixer"
@@ -408,6 +418,18 @@ class IVideoMixer(IBackendPlugin):
         """
         raise NotImplementedError
 
+    def get_resolution_pixels(self):
+        """
+        Returns the total number of pixels in the selected from the video input plugin.
+        """
+        raise NotImplementedError
+
+    def supports_video_quality(self):
+        """
+        Returns True if the current video input plugin supports video quality else returns False.
+        """
+        return False
+
 
 class IOutput(IBackendPlugin):
     #
@@ -432,6 +454,7 @@ class IOutput(IBackendPlugin):
     type = None  # Types: AUDIO, VIDEO, BOTH
     extension = None
     location = None
+    configurable = False
 
     metadata_order = [
         "title",
@@ -478,6 +501,20 @@ class IOutput(IBackendPlugin):
             node.text = metadata[key]
 
         return ET.ElementTree(root)
+
+    def set_audio_quality(self, quality):
+        """Implement this to set the audio quality of the plugin.
+
+        Input quality is either LOW, MEDIUM, or HIGH.
+        """
+        pass
+
+    def set_video_bitrate(self, bitrate):
+        """Implement this to set the bitrate of the plugin.
+
+        Only implement if the bitrate of the plugin can be specified.
+        """
+        pass
 
 
 class IImporter(IBackendPlugin):

--- a/src/freeseer/frontend/configtool/AVWidget.py
+++ b/src/freeseer/frontend/configtool/AVWidget.py
@@ -29,6 +29,7 @@ http://wiki.github.com/Freeseer/freeseer/
 from PyQt4 import QtCore
 from PyQt4 import QtGui
 
+from freeseer.framework.multimedia import Quality
 from freeseer.frontend.qtcommon.dpi_adapt_qtgui import QGroupBoxWithDpi
 from freeseer.frontend.qtcommon.dpi_adapt_qtgui import QWidgetWithDpi
 
@@ -71,7 +72,7 @@ class AVWidget(QWidgetWithDpi):
 
         self.audioGroupBox.setCheckable(True)
         self.audioGroupBox.setSizePolicy(QtGui.QSizePolicy.Fixed, QtGui.QSizePolicy.Fixed)
-        self.audioGroupBox.setFixedSize(BOX_WIDTH, BOX_HEIGHT)
+        self.audioGroupBox.setFixedSize(BOX_WIDTH, 1.5 * BOX_HEIGHT)
         self.audioGroupBox.setStyleSheet(boxStyle)
 
         self.audioMixerLabel = QtGui.QLabel("Audio Mixer")
@@ -87,6 +88,21 @@ class AVWidget(QWidgetWithDpi):
         audioLayout.addWidget(self.audioMixerComboBox, 0, 1)
         audioLayout.addWidget(self.audioMixerSetupPushButton, 0, 2)
 
+        self.audioQualityLabel = QtGui.QLabel("Audio Quality")
+        self.audioQualityLabel.setSizePolicy(QtGui.QSizePolicy.Maximum, QtGui.QSizePolicy.Maximum)
+        self.audioQualityComboBox = QtGui.QComboBox()
+        self.audioQualityComboBox.addItems(Quality.qualities)
+        self.audioQualityLabel.setBuddy(self.audioQualityComboBox)
+        self.audioQualitySetupPushButton = QtGui.QToolButton()
+        self.audioQualitySetupPushButton.setText("Setup")
+        self.audioQualitySetupPushButton.setIcon(config_icon)
+        self.audioQualitySetupPushButton.setSizePolicy(QtGui.QSizePolicy.Maximum, QtGui.QSizePolicy.Maximum)
+        self.audioQualitySetupPushButton.setToolButtonStyle(QtCore.Qt.ToolButtonIconOnly)
+        self.audioQualitySetupPushButton.setEnabled(False)
+        audioLayout.addWidget(self.audioQualityLabel, 1, 0)
+        audioLayout.addWidget(self.audioQualityComboBox, 1, 1)
+        audioLayout.addWidget(self.audioQualitySetupPushButton, 1, 2)
+
         #
         # Video Input
         #
@@ -98,7 +114,7 @@ class AVWidget(QWidgetWithDpi):
 
         self.videoGroupBox.setCheckable(True)
         self.videoGroupBox.setSizePolicy(QtGui.QSizePolicy.Fixed, QtGui.QSizePolicy.Fixed)
-        self.videoGroupBox.setFixedSize(BOX_WIDTH, BOX_HEIGHT)
+        self.videoGroupBox.setFixedSize(BOX_WIDTH, 1.5 * BOX_HEIGHT)
         self.videoGroupBox.setStyleSheet(boxStyle)
 
         self.videoMixerLabel = QtGui.QLabel("Video Mixer")
@@ -113,6 +129,21 @@ class AVWidget(QWidgetWithDpi):
         videoLayout.addWidget(self.videoMixerLabel, 0, 0)
         videoLayout.addWidget(self.videoMixerComboBox, 0, 1)
         videoLayout.addWidget(self.videoMixerSetupPushButton, 0, 2)
+
+        self.videoQualityLabel = QtGui.QLabel("Video Quality")
+        self.videoQualityLabel.setSizePolicy(QtGui.QSizePolicy.Maximum, QtGui.QSizePolicy.Maximum)
+        self.videoQualityComboBox = QtGui.QComboBox()
+        self.videoQualityComboBox.addItems(Quality.qualities)
+        self.videoQualityLabel.setBuddy(self.videoQualityComboBox)
+        self.videoQualitySetupPushButton = QtGui.QToolButton()
+        self.videoQualitySetupPushButton.setText("Setup")
+        self.videoQualitySetupPushButton.setIcon(config_icon)
+        self.videoQualitySetupPushButton.setSizePolicy(QtGui.QSizePolicy.Maximum, QtGui.QSizePolicy.Maximum)
+        self.videoQualitySetupPushButton.setToolButtonStyle(QtCore.Qt.ToolButtonIconOnly)
+        self.videoQualitySetupPushButton.setEnabled(False)
+        videoLayout.addWidget(self.videoQualityLabel, 1, 0)
+        videoLayout.addWidget(self.videoQualityComboBox, 1, 1)
+        videoLayout.addWidget(self.videoQualitySetupPushButton, 1, 2)
 
         #
         # Record to Stream

--- a/src/freeseer/frontend/configtool/ConfigToolWidget.py
+++ b/src/freeseer/frontend/configtool/ConfigToolWidget.py
@@ -48,7 +48,7 @@ class ConfigToolWidget(QWidgetWithDpi):
         '''
         super(ConfigToolWidget, self).__init__(parent)
 
-        self.setMinimumSize(800, 400)
+        self.setMinimumSize(800, 460)
         self.mainLayout = QtGui.QHBoxLayout()
         self.setLayout(self.mainLayout)
 

--- a/src/freeseer/plugins/output/ogg_icecast/widget.py
+++ b/src/freeseer/plugins/output/ogg_icecast/widget.py
@@ -26,7 +26,9 @@ http://wiki.github.com/Freeseer/freeseer/
 @author: Thanh Ha
 '''
 
+from PyQt4.QtGui import QDoubleSpinBox
 from PyQt4.QtGui import QFormLayout
+from PyQt4.QtGui import QHBoxLayout
 from PyQt4.QtGui import QLabel
 from PyQt4.QtGui import QLineEdit
 from PyQt4.QtGui import QSpinBox
@@ -58,3 +60,39 @@ class ConfigWidget(QWidget):
         self.label_mount = QLabel("Mount")
         self.lineedit_mount = QLineEdit()
         layout.addRow(self.label_mount, self.lineedit_mount)
+
+        #
+        # Audio Quality
+        #
+
+        self.label_audio_quality = QLabel("Audio Quality")
+        self.spinbox_audio_quality = QDoubleSpinBox()
+        self.spinbox_audio_quality.setMinimum(0.0)
+        self.spinbox_audio_quality.setMaximum(1.0)
+        self.spinbox_audio_quality.setSingleStep(0.1)
+        self.spinbox_audio_quality.setDecimals(1)
+        self.spinbox_audio_quality.setValue(0.3)            # Default value 0.3
+
+        #
+        # Video Quality
+        #
+
+        self.label_video_quality = QLabel("Video Quality (kb/s)")
+        self.spinbox_video_quality = QSpinBox()
+        self.spinbox_video_quality.setMinimum(0)
+        self.spinbox_video_quality.setMaximum(16777215)
+        self.spinbox_video_quality.setValue(2400)           # Default value 2400
+
+    def get_video_quality_layout(self):
+        layout_video_quality = QHBoxLayout()
+        layout_video_quality.addWidget(self.label_video_quality)
+        layout_video_quality.addWidget(self.spinbox_video_quality)
+
+        return layout_video_quality
+
+    def get_audio_quality_layout(self):
+        layout_audio_quality = QHBoxLayout()
+        layout_audio_quality.addWidget(self.label_audio_quality)
+        layout_audio_quality.addWidget(self.spinbox_audio_quality)
+
+        return layout_audio_quality

--- a/src/freeseer/plugins/output/ogg_output/widget.py
+++ b/src/freeseer/plugins/output/ogg_output/widget.py
@@ -29,6 +29,7 @@ http://wiki.github.com/Freeseer/freeseer/
 from PyQt4.QtGui import QCheckBox
 from PyQt4.QtGui import QDoubleSpinBox
 from PyQt4.QtGui import QFormLayout
+from PyQt4.QtGui import QHBoxLayout
 from PyQt4.QtGui import QLabel
 from PyQt4.QtGui import QSpinBox
 from PyQt4.QtGui import QWidget
@@ -53,7 +54,6 @@ class ConfigWidget(QWidget):
         self.spinbox_audio_quality.setSingleStep(0.1)
         self.spinbox_audio_quality.setDecimals(1)
         self.spinbox_audio_quality.setValue(0.3)            # Default value 0.3
-        layout.addRow(self.label_audio_quality, self.spinbox_audio_quality)
 
         #
         # Video Quality
@@ -64,7 +64,6 @@ class ConfigWidget(QWidget):
         self.spinbox_video_quality.setMinimum(0)
         self.spinbox_video_quality.setMaximum(16777215)
         self.spinbox_video_quality.setValue(2400)           # Default value 2400
-        layout.addRow(self.label_video_quality, self.spinbox_video_quality)
 
         #
         # Misc.
@@ -73,3 +72,17 @@ class ConfigWidget(QWidget):
         self.label_matterhorn.setToolTip("Generates Matterhorn Metadata in XML format")
         self.checkbox_matterhorn = QCheckBox()
         layout.addRow(self.label_matterhorn, self.checkbox_matterhorn)
+
+    def get_video_quality_layout(self):
+        layout_video_quality = QHBoxLayout()
+        layout_video_quality.addWidget(self.label_video_quality)
+        layout_video_quality.addWidget(self.spinbox_video_quality)
+
+        return layout_video_quality
+
+    def get_audio_quality_layout(self):
+        layout_audio_quality = QHBoxLayout()
+        layout_audio_quality.addWidget(self.label_audio_quality)
+        layout_audio_quality.addWidget(self.spinbox_audio_quality)
+
+        return layout_audio_quality

--- a/src/freeseer/plugins/videoinput/desktop/__init__.py
+++ b/src/freeseer/plugins/videoinput/desktop/__init__.py
@@ -37,6 +37,7 @@ import gst
 
 # PyQt4 modules
 from PyQt4.QtCore import SIGNAL
+from PyQt4.QtGui import QApplication
 from PyQt4.QtGui import QDesktopWidget
 
 # Freeseer modules
@@ -168,6 +169,18 @@ class DesktopLinuxSrc(IVideoInput):
 
         return self.widget
 
+    def get_resolution_pixels(self):
+        self.get_config()
+
+        if self.config.desktop == "Full":
+            app = QApplication.instance()
+            screen_rect = app.desktop().screenGeometry()
+            return screen_rect.width() * screen_rect.height()
+        elif self.config.desktop == "Area":
+            width = self.config.end_x - self.config.start_x
+            height = self.config.end_y - self.config.start_y
+            return width * height
+
     def __enable_connections(self):
         self.widget.connect(self.widget.desktopButton, SIGNAL('clicked()'), self.set_desktop_full)
         self.widget.connect(self.widget.areaButton, SIGNAL('clicked()'), self.set_desktop_area)
@@ -175,7 +188,7 @@ class DesktopLinuxSrc(IVideoInput):
         self.widget.connect(self.widget.screenSpinBox, SIGNAL('valueChanged(int)'), self.set_screen)
 
     def widget_load_config(self, plugman):
-        self.load_config(plugman)
+        self.get_config()
 
         if self.config.desktop == "Full":
             self.widget.desktopButton.setChecked(True)
@@ -200,10 +213,12 @@ class DesktopLinuxSrc(IVideoInput):
     def set_desktop_full(self):
         self.config.desktop = "Full"
         self.config.save()
+        self.gui.update_video_quality()
 
     def set_desktop_area(self):
         self.config.desktop = "Area"
         self.config.save()
+        self.gui.update_video_quality()
 
     ###
     ### Translations

--- a/src/freeseer/plugins/videomixer/pip/__init__.py
+++ b/src/freeseer/plugins/videomixer/pip/__init__.py
@@ -56,6 +56,8 @@ class PictureInPicture(IVideoMixer):
     os = ["linux", "linux2", "win32", "cygwin", "darwin"]
     widget = None
     CONFIG_CLASS = PictureInPictureConfig
+    WIDTH = 640
+    HEIGHT = 480
 
     def get_videomixer_bin(self):
         bin = gst.Bin()
@@ -115,7 +117,7 @@ class PictureInPicture(IVideoMixer):
         # Create capsfilter for limiting to x-raw-rgb pixel video format and setting dimensions
         mainsrc_capsfilter = gst.element_factory_make("capsfilter", "mainsrc_capsfilter")
         mainsrc_capsfilter.set_property('caps',
-                        gst.caps_from_string('video/x-raw-rgb, width=640, height=480'))
+                        gst.caps_from_string('video/x-raw-rgb, width={}, height={}'.format(self.WIDTH, self.HEIGHT)))
 
         mainsrc_elements = [input1, mainsrc_scale, mainsrc_capsfilter, mainsrc_colorspace]
 
@@ -171,7 +173,7 @@ class PictureInPicture(IVideoMixer):
         self.widget.connect(self.widget.pipInputSetupButton, SIGNAL('clicked()'), self.open_pipInputSetup)
 
     def widget_load_config(self, plugman):
-        self.load_config(plugman)
+        self.get_config()
 
         sources = []
         plugins = self.plugman.get_videoinput_plugins()
@@ -194,6 +196,12 @@ class PictureInPicture(IVideoMixer):
 
         # Finally enable connections
         self.__enable_connections()
+
+    def supports_video_quality(self):
+        return True
+
+    def get_resolution_pixels(self):
+        return self.WIDTH * self.HEIGHT
 
     ###
     ### Main Input Functions

--- a/src/freeseer/plugins/videomixer/videopassthrough/__init__.py
+++ b/src/freeseer/plugins/videomixer/videopassthrough/__init__.py
@@ -117,6 +117,21 @@ class VideoPassthrough(IVideoMixer):
         inputs = [(self.config.input, 0)]
         return inputs
 
+    def get_resolution_pixels(self):
+        self.get_config()
+
+        if self.config.resolution == "No Scaling":
+            plugin = self.plugman.get_plugin_by_name(self.config.input, "VideoInput")
+            return plugin.plugin_object.get_resolution_pixels()
+        else:
+            width, height = widget.resmap[str(self.config.resolution)]
+            return width * height
+
+    def supports_video_quality(self):
+        self.get_config()
+
+        return self.config.input == "Desktop Source"
+
     def load_inputs(self, player, mixer, inputs):
         # Load source
         input = inputs[0]
@@ -139,7 +154,7 @@ class VideoPassthrough(IVideoMixer):
         self.widget.connect(self.widget.videoscaleComboBox, SIGNAL("currentIndexChanged(const QString&)"), self.set_videoscale)
 
     def widget_load_config(self, plugman):
-        self.load_config(plugman)
+        self.get_config()
 
         sources = []
         plugins = self.plugman.get_videoinput_plugins()
@@ -178,6 +193,7 @@ class VideoPassthrough(IVideoMixer):
         self.config.input = input
         self.config.save()
         self.__enable_source_setup(self.config.input)
+        self.gui.toggle_video_quality(input == "Desktop Source")
 
     def __enable_source_setup(self, source):
         '''Activates the source setup button if it has configurable settings'''
@@ -198,6 +214,7 @@ class VideoPassthrough(IVideoMixer):
     def set_videoscale(self, resolution):
         self.config.resolution = resolution
         self.config.save()
+        self.gui.update_video_quality()
 
     ###
     ### Translations

--- a/src/freeseer/settings.py
+++ b/src/freeseer/settings.py
@@ -28,6 +28,7 @@ from PyQt4.QtCore import QLocale
 
 from freeseer.framework.config.core import Config
 from freeseer.framework.config.profile import ProfileManager
+from freeseer.framework.multimedia import Quality
 import freeseer.framework.config.options as options
 
 # TODO: change to config_dir when all the pull requests from UCOSP Fall 2013 are merged in
@@ -57,7 +58,9 @@ class FreeseerConfig(Config):
     enable_audio_recording = options.BooleanOption(True)
     enable_video_recording = options.BooleanOption(True)
     videomixer = options.StringOption('Video Passthrough')
+    video_quality = options.IntegerOption(Quality.CUSTOM)
     audiomixer = options.StringOption('Audio Passthrough')
+    audio_quality = options.IntegerOption(Quality.CUSTOM)
     record_to_file = options.BooleanOption(True)
     record_to_file_plugin = options.StringOption('Ogg Output')
     record_to_stream = options.BooleanOption(False)

--- a/src/freeseer/tests/framework/test_config.py
+++ b/src/freeseer/tests/framework/test_config.py
@@ -89,9 +89,17 @@ class TestConfig(unittest.TestCase):
                     'default': 'Video Passthrough',
                     'type': 'string',
                 },
+                'video_quality': {
+                    'default': 3,
+                    'type': 'integer',
+                },
                 'audiomixer': {
                     'default': 'Audio Passthrough',
                     'type': 'string',
+                },
+                'audio_quality': {
+                    'default': 3,
+                    'type': 'integer',
                 },
                 'record_to_file': {
                     'default': True,


### PR DESCRIPTION
Fix #623. Easier configuration for output quality of video and audio by using a combo box to select. The bitrate determined for video will be based on the system resolution.

Tasks:
- [x] Add ComboBoxes for quality selection
- [x] Have ComboBox selection set qualities for Ogg Output
- [x] Have ComboBox selection set qualities for all plugins
- [x] Save ComboBox selection in profile and whether it should be used or has been overridden by manual quality entry
- [x] Add config support for Ogg Icecast
- [x] Disable config button and quality comboboxes when RAW or WebM Output is selected
- [x] Support scaling
- [x] Support non-screen inputs (NOT POSSIBLE)
- [x] Recompute video bitrate based on quality and resolution on record if "No Scaling"

Screen:
![quality selection](https://cloud.githubusercontent.com/assets/5759678/4958137/1ff74286-66ab-11e4-85b9-a0fe68cb225b.png)
