### PR TITLE
Fix #654 - Generates valid defaults for multi-device plugins

### DIFF
--- a/src/freeseer/plugins/audioinput/pulsesrc/__init__.py
+++ b/src/freeseer/plugins/audioinput/pulsesrc/__init__.py
@@ -60,9 +60,18 @@ def get_sources():
     return zip(names, names)
 
 
+def get_default_source():
+    """Returns the default audio source."""
+    sources = get_sources()
+    if not sources:
+        return ''
+    else:
+        return sources[0][0]
+
+
 class PulseSrcConfig(Config):
     """Default PulseSrc config settings."""
-    source = options.StringOption('')
+    source = options.StringOption(get_default_source())
 
 
 class PulseSrc(IAudioInput):

--- a/src/freeseer/plugins/videoinput/firewiresrc/__init__.py
+++ b/src/freeseer/plugins/videoinput/firewiresrc/__init__.py
@@ -65,9 +65,17 @@ def detect_devices():
     return device_list
 
 
+def get_default_device():
+    """Returns a default recording device from get_devices()."""
+    devices = detect_devices()
+    if not devices:
+        return ''
+    return devices[0]
+
+
 class FirewireSrcConfig(Config):
     """Config settings for Firewire video source."""
-    device = options.StringOption('')
+    device = options.StringOption(get_default_device())
 
 
 class FirewireSrc(IVideoInput):

--- a/src/freeseer/plugins/videoinput/usbsrc/__init__.py
+++ b/src/freeseer/plugins/videoinput/usbsrc/__init__.py
@@ -85,9 +85,18 @@ def get_devices():
     return devicemap
 
 
+def get_default_device():
+    """Returns a default recording device from get_devices()."""
+    devicemap = get_devices()
+    if not devicemap:
+        return ''
+    default = devicemap.itervalues().next()
+    return default
+
+
 class USBSrcConfig(Config):
     """USBSrc Configuration settings."""
-    device = options.StringOption('')
+    device = options.StringOption(get_default_device())
 
 
 class USBSrc(IVideoInput):


### PR DESCRIPTION
Adds methods to find a valid default input/source device for plugins that had previously hard-coded default values.

Affected plugins:
- USB Source Video
- Pulse Source Audio
- Firewire Video
