### PR TITLE
Fixes 658: Error during startup for windows missing plugin

### DIFF
--- a/src/freeseer/plugins/audioinput/pulsesrc/__init__.py
+++ b/src/freeseer/plugins/audioinput/pulsesrc/__init__.py
@@ -71,7 +71,7 @@ def get_default_source():
 
 class PulseSrcConfig(Config):
     """Default PulseSrc config settings."""
-    source = options.StringOption(get_default_source())
+    source = options.StringOption('')
 
 
 class PulseSrc(IAudioInput):
@@ -84,9 +84,11 @@ class PulseSrc(IAudioInput):
 
         audiosrc = gst.element_factory_make("pulsesrc", "audiosrc")
 
-        if self.config.source:
-            audiosrc.set_property('device', self.config.source)
-            log.debug('Pulseaudio source is set to %s', audiosrc.get_property('device'))
+        if not self.config.source:
+            self.config.source = get_default_source()
+
+        audiosrc.set_property('device', self.config.source)
+        log.debug('Pulseaudio source is set to %s', audiosrc.get_property('device'))
 
         bin.add(audiosrc)
 

--- a/src/freeseer/plugins/videoinput/firewiresrc/__init__.py
+++ b/src/freeseer/plugins/videoinput/firewiresrc/__init__.py
@@ -75,7 +75,7 @@ def get_default_device():
 
 class FirewireSrcConfig(Config):
     """Config settings for Firewire video source."""
-    device = options.StringOption(get_default_device())
+    device = options.StringOption('')
 
 
 class FirewireSrc(IVideoInput):
@@ -88,6 +88,9 @@ class FirewireSrc(IVideoInput):
 
     def get_videoinput_bin(self):
         bin = gst.Bin()  # Do not pass a name so that we can load this input more than once.
+
+        if not self.config.device:
+            self.config.device = get_default_device()
 
         videosrc = gst.element_factory_make("dv1394src", "videosrc")
         dv1394q1 = gst.element_factory_make('queue', 'dv1394q1')

--- a/src/freeseer/plugins/videoinput/usbsrc/__init__.py
+++ b/src/freeseer/plugins/videoinput/usbsrc/__init__.py
@@ -96,7 +96,7 @@ def get_default_device():
 
 class USBSrcConfig(Config):
     """USBSrc Configuration settings."""
-    device = options.StringOption(get_default_device())
+    device = options.StringOption('')
 
 
 class USBSrc(IVideoInput):
@@ -114,6 +114,9 @@ class USBSrc(IVideoInput):
         bin = gst.Bin()  # Do not pass a name so that we can load this input more than once.
 
         videosrc = None
+
+        if not self.config.device:
+            self.config.device = get_default_device()
 
         if sys.platform.startswith("linux"):
             videosrc = gst.element_factory_make("v4l2src", "videosrc")


### PR DESCRIPTION
Fixes #658: Error during startup for windows missing plugin

I have moved the calls to get_default_device() methods into the affected plugins' get_videoinput_bin() (get_audioinput_bin() for Pulsesrc) methods. This ensures that get_default_device() is only called when the plugin actually gets used, instead of during freeseer initialization.

Previously, the Yapsy PluginManager was loading the plugin module during initialization, which was causing get_default_device() to run, which in turn calls a get_devices() method. In the case of Pulsesrc audio, get_devices() attempts to probe the plugin which doesn't exist in windows.
