### PR TITLE
Fix #653 Dialog not hidden on desktop region selection

### DIFF
--- a/src/freeseer/frontend/configtool/configtool.py
+++ b/src/freeseer/frontend/configtool/configtool.py
@@ -67,6 +67,8 @@ class ConfigToolApp(FreeseerApp):
         # Initialize geometry, to be used for restoring window positioning.
         self.geometry = None
 
+        self.dialog = None
+
         self.mainWidget = ConfigToolWidget()
         self.setCentralWidget(self.mainWidget)
 
@@ -564,6 +566,7 @@ class ConfigToolApp(FreeseerApp):
 
     def show_plugin_widget_dialog(self, widget, name):
         """Shows the configuration dialog for a plugin."""
+        self.last_dialog = self.dialog
         self.dialog = QtGui.QDialog(self)
 
         self.dialog_layout = QtGui.QVBoxLayout()

--- a/src/freeseer/plugins/videoinput/desktop/__init__.py
+++ b/src/freeseer/plugins/videoinput/desktop/__init__.py
@@ -128,6 +128,7 @@ class DesktopLinuxSrc(IVideoInput):
         self.area_selector = AreaSelector(self)
         self.area_selector.show()
         self.gui.hide()
+        self.gui.last_dialog.hide()
         self.widget.window().hide()
 
     def areaSelectEvent(self, start_x, start_y, end_x, end_y):
@@ -142,6 +143,7 @@ class DesktopLinuxSrc(IVideoInput):
         self.widget.areaButton.setChecked(True)
 
         self.gui.show()
+        self.gui.last_dialog.show()
         self.widget.window().show()
 
     def get_widget(self):


### PR DESCRIPTION
Fix #653

The Video Passthrough dialog was not being hidden when selecting a region for Desktop Source. This is fixed now.
