### PR TITLE
Fix #664 Feedback when desktop record region selected

### DIFF
--- a/src/freeseer/plugins/videoinput/desktop/__init__.py
+++ b/src/freeseer/plugins/videoinput/desktop/__init__.py
@@ -155,6 +155,8 @@ class DesktopLinuxSrc(IVideoInput):
         # Automatically check the "Record Region" button.
         self.set_desktop_area()
         self.widget.areaButton.setChecked(True)
+        self.widget.regionLabel.setText("{}x{} to {}x{}".format(
+            self.config.start_x, self.config.start_y, self.config.end_x, self.config.end_y))
 
         self.gui.show()
         self.gui.last_dialog.show()
@@ -184,6 +186,9 @@ class DesktopLinuxSrc(IVideoInput):
         # minus 1 since we like to start count at 0
         max_screens = QDesktopWidget().screenCount()
         self.widget.screenSpinBox.setMaximum(max_screens - 1)
+
+        self.widget.regionLabel.setText("{}x{} to {}x{}".format(
+            self.config.start_x, self.config.start_y, self.config.end_x, self.config.end_y))
 
         # Finally enable connections
         self.__enable_connections()

--- a/src/freeseer/plugins/videoinput/desktop/widget.py
+++ b/src/freeseer/plugins/videoinput/desktop/widget.py
@@ -56,6 +56,10 @@ class ConfigWidget(QWidget):
         areaGroup.addWidget(self.setAreaButton)
         layout.addRow(self.areaLabel, areaGroup)
 
+        self.regionLabel = QLabel("")
+        self.regionLabel.setStyleSheet("QLabel { background-color: #ADADAD; border: 1px solid gray }")
+        layout.addRow(QLabel(""), self.regionLabel)
+
         # Select screen to record
         self.screenLabel = QLabel("Screen")
         self.screenSpinBox = QSpinBox()


### PR DESCRIPTION
Fix #664. Added a label that shows the start and end coordinates of the desktop region selected.

![region show](https://cloud.githubusercontent.com/assets/5759678/5158389/5d70878e-7309-11e4-9581-ad434a438bf9.png)
