### PR TITLE
Fix #650: Resetting configuration raises error when file do not exist

### DIFF
--- a/src/freeseer/framework/util.py
+++ b/src/freeseer/framework/util.py
@@ -149,7 +149,7 @@ def reset_database(configdir, profile='default'):
 
     if validate_configdir(configdir):
         dbfile = os.path.join(configdir, 'profiles', profile, 'presentations.db')
-        
+
         if os.path.exists(dbfile):
             os.remove(dbfile)
     else:


### PR DESCRIPTION
Fix #650 
## Completed
- [x] Config file existence condition is checked before os.remove
