### PR TITLE
Fix #627: Clear fields in talkDetailsWidget in Talk Editor when removing a talk

### DIFF
--- a/src/freeseer/frontend/talkeditor/TalkDetailsWidget.py
+++ b/src/freeseer/frontend/talkeditor/TalkDetailsWidget.py
@@ -144,6 +144,14 @@ class TalkDetailsWidget(QWidget):
             self.endTimeEdit.setEnabled(False)
             self.descriptionTextEdit.setEnabled(False)
 
+    def clear_input_fields(self):
+            self.titleLineEdit.clear()
+            self.presenterLineEdit.clear()
+            self.categoryLineEdit.clear()
+            self.eventLineEdit.clear()
+            self.roomLineEdit.clear()
+            self.descriptionTextEdit.clear()
+
 if __name__ == "__main__":
     import sys
     from PyQt4.QtGui import QApplication

--- a/src/freeseer/frontend/talkeditor/talkeditor.py
+++ b/src/freeseer/frontend/talkeditor/talkeditor.py
@@ -461,6 +461,8 @@ class TalkEditorApp(FreeseerApp):
         # Reversed because rows in list change position once row is removed
         for row in reversed(rows_selected):
             self.presentationModel.removeRow(row.row())
+        self.talkDetailsWidget.clear_input_fields()
+        self.talkDetailsWidget.disable_input_fields()
 
     def load_talk(self):
         try:
@@ -474,6 +476,8 @@ class TalkEditorApp(FreeseerApp):
     def reset(self):
         self.db.clear_database()
         self.presentationModel.select()
+        self.talkDetailsWidget.clear_input_fields()
+        self.talkDetailsWidget.disable_input_fields()
 
     def confirm_reset(self):
         """Presents a confirmation dialog to ask the user if they are sure they wish to remove the talk database.


### PR DESCRIPTION
I noticed issue #627 and thought I would take a shot at fixing it.

EDIT: I just noticed the issue number was 627 and this pull request is 672. That makes me oddly happy.
