### PR TITLE
Fix PEP8 coding style violations (all but E501)

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,7 +30,7 @@ extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest', 'sphinx.ext.viewcode',
 
 # If True, the todo and todolist directives will produce output.
 # http://sphinx.pocoo.org/ext/todo.html#module-sphinx.ext.todo
-todo_include_todos=True
+todo_include_todos = True
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/src/freeseer/framework/multimedia.py
+++ b/src/freeseer/framework/multimedia.py
@@ -212,13 +212,13 @@ class Multimedia:
 
         To be used for populating the current recording's file metadata.
         """
-        return {"title":     presentation.title,
-                "artist":    presentation.speaker,
+        return {"title": presentation.title,
+                "artist": presentation.speaker,
                 "performer": presentation.speaker,
-                "album":     presentation.event,
-                "location":  presentation.room,
-                "date":      str(datetime.date.today()),
-                "comment":   presentation.description}
+                "album": presentation.event,
+                "location": presentation.room,
+                "date": str(datetime.date.today()),
+                "comment": presentation.description}
 
     ##
     ## Plugin Loading

--- a/src/freeseer/framework/plugin.py
+++ b/src/freeseer/framework/plugin.py
@@ -62,8 +62,8 @@ class PluginManager(QtCore.QObject):
             "AudioMixer": IAudioMixer,
             "VideoInput": IVideoInput,
             "VideoMixer": IVideoMixer,
-            "Importer":   IImporter,
-            "Output":     IOutput})
+            "Importer": IImporter,
+            "Output": IOutput})
         self.plugmanc.collectPlugins()
 
         for plugin in self.plugmanc.getAllPlugins():


### PR DESCRIPTION
I ran `pep8 --ignore=E501 *.py` and fixed some minor errors.

TODO: Fix E501 errors.

As part of http://24pullrequests.com/
