### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,6 @@ Documentation: http://freeseer.readthedocs.org
 [coverage-status]: https://coveralls.io/r/Freeseer/freeseer "Test coverage"
 [coverage-status-badge]: https://coveralls.io/repos/Freeseer/freeseer/badge.png
 [pypi-version]: https://crate.io/packages/freeseer "Latest version hosted on PyPi"
-[pypi-version-badge]: https://pypip.in/v/freeseer/badge.png
+[pypi-version-badge]: https://img.shields.io/pypi/v/freeseer.svg
 [pypi-downloads]: https://crate.io/packages/freeseer "Number of downloads from PyPi"
-[pypi-downloads-badge]: https://pypip.in/d/freeseer/badge.png
+[pypi-downloads-badge]: https://img.shields.io/pypi/dm/freeseer.svg


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20freeseer))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `freeseer`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.